### PR TITLE
Add opt-in reliable delivery (acks + client retransmit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,3 +117,4 @@ jobs:
           PORT=3777 bun provider_check.mjs
           PORT=3777 bun audit_scenarios.mjs
           PORT=3777 bun audit.mjs
+          PORT=3777 bun reliable.mjs

--- a/README.md
+++ b/README.md
@@ -292,6 +292,38 @@ mode (in [`examples/actioncable-demo`](examples/actioncable-demo)) wires
 `on_change` to an fsync'd append-only log and checks, end to end, that the log
 alone rebuilds the document.
 
+#### Reliable delivery (acks)
+
+The y-websocket protocol is fire-and-forget. If a client's update is lost in
+transit (a flaky socket, a send that never lands) and the client makes no
+further edits, the server stays idle and never asks anyone to resync, so that
+edit is gone -- even though the client believes it was saved. CRDTs converge the
+state everyone *has*; they don't recover an update that never arrived.
+
+yrb-lite closes that gap with an opt-in, client-driven acknowledgement. If an
+incoming frame carries an `"id"`, the server replies `{ "ack": <id> }` once the
+update has been **accepted** -- recorded in audit mode, applied in fast mode. A
+causally-gapped update is not acked (it gets a resync instead), so the client
+knows it hasn't landed yet.
+
+```
+client -> server   { "m": "<base64 update>", "id": 42 }
+server -> client    { "ack": 42 }     # update accepted; safe to forget
+```
+
+That's the whole server side. A reliable client tags each outgoing update with
+an incrementing id, keeps it in a pending buffer, and retransmits on a timer (and
+on reconnect) until the matching ack returns. Because CRDT apply is idempotent, a
+resend that already landed is a harmless no-op that just re-acks. An update lost
+in transit is recovered by the client's own retransmit -- no reconnect required,
+and no dependence on a later edit happening to trigger a resync.
+
+This is entirely **self-gating**: stock clients send no `"id"`, so they never get
+acks and behave exactly as before. Only a client that opts in by tagging its
+frames participates. A reference reliable client and an end-to-end test that loses
+an update mid-flight and recovers it purely by retransmit live in
+[`examples/actioncable-demo/frontend/reliable.mjs`](examples/actioncable-demo/frontend/reliable.mjs).
+
 ### User Awareness/Presence
 
 ```ruby

--- a/examples/actioncable-demo/frontend/reliable.mjs
+++ b/examples/actioncable-demo/frontend/reliable.mjs
@@ -1,0 +1,233 @@
+// Reliable-delivery test: proves a silently-lost client->server update is
+// recovered by the client's own retransmit -- no reconnect, no follow-up edit
+// to trigger a resync. This is the "fire-and-forget send never reached the
+// server" failure that a plain CRDT provider loses forever (the server is idle,
+// so it never knows anything is missing and never asks anyone to resync).
+//
+//   1. Boot the Rails server:  bin/rails s -p 3777   (AUDIT=1 also works)
+//   2. Run:                    cd frontend && bun reliable.mjs
+//
+// The reliable client tags each outgoing update with an incrementing id, keeps
+// it in a pending buffer, and retransmits on a timer until the server returns
+// `{ ack: <id> }`. Idempotent CRDT apply makes resends free. Stock clients send
+// no id, never get acks, and are unaffected.
+import * as Y from "yjs"
+import * as syncProtocol from "y-protocols/sync"
+import * as encoding from "lib0/encoding"
+import * as decoding from "lib0/decoding"
+
+const PORT = process.env.PORT || 3777
+const ROOM = `reliable-${process.pid}`
+const MSG_SYNC = 0
+const MSG_AWARENESS = 1
+
+const toBase64 = (bytes) => Buffer.from(bytes).toString("base64")
+const fromBase64 = (b64) => new Uint8Array(Buffer.from(b64, "base64"))
+
+// A minimal ack-aware provider: the reference client of the reliable layer.
+class ReliableClient {
+  constructor(name, { retransmitMs = 200 } = {}) {
+    this.name = name
+    this.doc = new Y.Doc()
+    this.identifier = JSON.stringify({ channel: "DocumentChannel", id: ROOM })
+    this.subscribed = new Promise((resolve) => (this._onSubscribed = resolve))
+
+    this.nextId = 1
+    this.pending = new Map() // id -> frame bytes, retained until acked
+    this.acked = [] // ids the server has acknowledged
+    this.blackhole = false // test hook: drop every wire send (models an outage)
+    this.dropped = 0
+
+    this.doc.on("update", (update, origin) => {
+      if (origin === "remote") return
+      const enc = encoding.createEncoder()
+      encoding.writeVarUint(enc, MSG_SYNC)
+      syncProtocol.writeUpdate(enc, update)
+      this.sendReliable(encoding.toUint8Array(enc))
+    })
+
+    this.timer = setInterval(() => this.retransmit(), retransmitMs)
+    this.ws = new WebSocket(`ws://localhost:${PORT}/cable`, ["actioncable-v1-json"])
+    this.ws.onmessage = (event) => this.onMessage(JSON.parse(event.data))
+  }
+
+  onMessage(msg) {
+    switch (msg.type) {
+      case "welcome":
+        this.ws.send(JSON.stringify({ command: "subscribe", identifier: this.identifier }))
+        return
+      case "confirm_subscription": {
+        const enc = encoding.createEncoder()
+        encoding.writeVarUint(enc, MSG_SYNC)
+        syncProtocol.writeSyncStep1(enc, this.doc)
+        this.sendRaw(encoding.toUint8Array(enc)) // handshake: no id, no ack expected
+        this._onSubscribed()
+        return
+      }
+      case "ping":
+      case "disconnect":
+        return
+    }
+    // Reliable-delivery ack: drop the matching update from the pending buffer.
+    if (msg.message?.ack !== undefined) {
+      this.pending.delete(msg.message.ack)
+      this.acked.push(msg.message.ack)
+      return
+    }
+    if (msg.message?.m) this.receiveBinary(fromBase64(msg.message.m))
+  }
+
+  receiveBinary(bytes) {
+    const decoder = decoding.createDecoder(bytes)
+    while (decoding.hasContent(decoder)) {
+      const type = decoding.readVarUint(decoder)
+      if (type === MSG_SYNC) {
+        const enc = encoding.createEncoder()
+        encoding.writeVarUint(enc, MSG_SYNC)
+        syncProtocol.readSyncMessage(decoder, enc, this.doc, "remote")
+        if (encoding.length(enc) > 1) this.sendRaw(encoding.toUint8Array(enc))
+      } else if (type === MSG_AWARENESS) {
+        decoding.readVarUint8Array(decoder) // ignore presence in this test
+      } else {
+        throw new Error(`${this.name}: unknown message type ${type}`)
+      }
+    }
+  }
+
+  // Tag an outgoing update with an id and retain it until acked.
+  sendReliable(frameBytes) {
+    const id = this.nextId++
+    this.pending.set(id, frameBytes)
+    this.transmit(id, frameBytes)
+  }
+
+  // Resend everything still unacked. Free to call repeatedly: the server's CRDT
+  // apply is idempotent, so a redundant resend is a no-op that re-acks.
+  retransmit() {
+    for (const [id, frameBytes] of this.pending) this.transmit(id, frameBytes)
+  }
+
+  transmit(id, frameBytes) {
+    if (this.blackhole) {
+      this.dropped++
+      return // simulate lost connectivity: the bytes never reach the server
+    }
+    this.ws.send(
+      JSON.stringify({
+        command: "message",
+        identifier: this.identifier,
+        data: JSON.stringify({ m: toBase64(frameBytes), id }),
+      })
+    )
+  }
+
+  // Protocol traffic with no reliability (handshake, SyncStep2 replies): no id.
+  sendRaw(frameBytes) {
+    this.ws.send(
+      JSON.stringify({
+        command: "message",
+        identifier: this.identifier,
+        data: JSON.stringify({ m: toBase64(frameBytes) }),
+      })
+    )
+  }
+
+  insertParagraph(text) {
+    const fragment = this.doc.getXmlFragment("default")
+    this.doc.transact(() => {
+      const paragraph = new Y.XmlElement("paragraph")
+      paragraph.insert(0, [new Y.XmlText(text)])
+      fragment.insert(fragment.length, [paragraph])
+    })
+  }
+
+  textContent() {
+    return this.doc.getXmlFragment("default").toString()
+  }
+
+  close() {
+    clearInterval(this.timer)
+    this.ws.close()
+  }
+}
+
+const waitFor = async (label, predicate, timeoutMs = 5000) => {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      console.log(`ok: ${label}`)
+      return
+    }
+    await new Promise((r) => setTimeout(r, 50))
+  }
+  throw new Error(`TIMEOUT waiting for: ${label}`)
+}
+
+const stayFalse = async (label, predicate, windowMs = 600) => {
+  const deadline = Date.now() + windowMs
+  while (Date.now() < deadline) {
+    if (predicate()) throw new Error(`EXPECTED-ABSENT but present: ${label}`)
+    await new Promise((r) => setTimeout(r, 50))
+  }
+  console.log(`ok: ${label}`)
+}
+
+// --- Scenario ---------------------------------------------------------------
+
+const alice = new ReliableClient("alice")
+await alice.subscribed
+
+const bob = new ReliableClient("bob")
+await bob.subscribed
+
+// 1. A normal edit is acked and drains the pending buffer.
+alice.insertParagraph("First edit")
+await waitFor("normal edit is acked (pending buffer drains)", () => alice.pending.size === 0)
+await waitFor("bob receives the first edit", () =>
+  bob.textContent().includes("First edit")
+)
+
+// 2. Alice loses connectivity, then edits: the send (and every retransmit) is
+//    dropped before reaching the server. Nothing else is sent, so the server
+//    stays idle and never asks anyone to resync -- a plain provider would lose
+//    this edit permanently.
+alice.blackhole = true
+alice.insertParagraph("Lost edit")
+
+// While the outage lasts, the edit is buffered and unacked; it never reaches
+// the server or Bob, and the retransmit timer keeps trying (and failing).
+await stayFalse("lost edit does not reach bob during the outage", () =>
+  bob.textContent().includes("Lost edit")
+)
+if (alice.pending.size === 0) {
+  throw new Error("lost edit must still be pending (unacked) during the outage")
+}
+if (alice.dropped < 2) {
+  throw new Error(`retransmit should have retried during the outage, saw ${alice.dropped} drops`)
+}
+console.log(`ok: the edit is buffered and retried ${alice.dropped}x during the outage (still unacked)`)
+
+// 3. Connectivity returns. The next retransmit reaches the server, which
+//    applies, acks, and relays it. Recovery is driven purely by the client
+//    retransmit -- no reconnect, no follow-up edit forcing a resync.
+alice.blackhole = false
+await waitFor("retransmit recovers the lost edit once connectivity returns (acked)",
+  () => alice.pending.size === 0)
+await waitFor("bob receives the recovered edit", () =>
+  bob.textContent().includes("Lost edit")
+)
+
+await waitFor("docs converge byte-for-byte", () => {
+  const a = Y.encodeStateAsUpdate(alice.doc)
+  const b = Y.encodeStateAsUpdate(bob.doc)
+  return a.length === b.length && a.every((byte, i) => byte === b[i])
+})
+
+if (alice.acked.length < 2) {
+  throw new Error(`expected at least 2 acks, saw ${alice.acked.length}`)
+}
+
+alice.close()
+bob.close()
+console.log(`\nPASS: room ${ROOM} (recovered a silently-lost update via retransmit)`)
+process.exit(0)

--- a/lib/yrb_lite/sync.rb
+++ b/lib/yrb_lite/sync.rb
@@ -128,6 +128,13 @@ module YrbLite
     # If an `on_change` recorder is registered, document changes take the
     # strict authoritative path (record -> apply -> broadcast, serialized per
     # document); otherwise the fast path is used.
+    #
+    # Reliable delivery (opt-in, client-driven): if the frame carries an "id",
+    # the server replies `{ "ack" => id }` once the update has been accepted
+    # (recorded in audit mode, applied in fast mode). A causally-gapped update
+    # is not acked -- it gets a resync instead -- so an ack-aware client knows
+    # to retransmit until the update lands. Stock clients send no "id", never
+    # get acks, and are completely unaffected.
     def sync_receive(data, key = nil)
       # Pass `key` (params[:id]) when your transport doesn't keep the channel
       # instance alive across actions. Under AnyCable each RPC command gets a
@@ -139,13 +146,23 @@ module YrbLite
       m = data.is_a?(Hash) ? (data["m"] || data["update"]) : nil
       return unless m.is_a?(String)
 
+      # Optional client-supplied id for reliable delivery (see sync_send_ack).
+      id = data.is_a?(Hash) ? data["id"] : nil
+
       begin
         bytes = Base64.strict_decode64(m)
       rescue ArgumentError
         return # not valid base64; ignore the frame and keep the connection
       end
 
-      return sync_receive_store_backed(m, bytes) if self.class.sync_backend == :store
+      sync_send_ack(id, sync_dispatch(m, bytes))
+    end
+
+    # Route a decoded frame to the backend/path that handles it and return the
+    # outcome symbol (:recorded/:applied/:gap/:noop) used by the reliable-
+    # delivery ack. A dropped frame returns nil (never acked).
+    def sync_dispatch(encoded, bytes)
+      return sync_receive_store_backed(encoded, bytes) if self.class.sync_backend == :store
 
       awareness = sync_awareness
       kind = awareness.message_kind(bytes)
@@ -156,9 +173,9 @@ module YrbLite
       sync_track_clients(awareness, bytes) if kind == MSG_KIND_AWARENESS
 
       if kind == MSG_KIND_UPDATE && self.class.on_change
-        sync_apply_authoritative(awareness, m, bytes)
+        sync_apply_authoritative(awareness, encoded, bytes)
       else
-        sync_apply_fast(awareness, m, bytes, kind)
+        sync_apply_fast(awareness, encoded, bytes, kind)
       end
     end
 
@@ -207,6 +224,10 @@ module YrbLite
     # Document changes (SyncStep2, Update) and awareness get relayed; requests
     # (SyncStep1, awareness-query) are answered above and not relayed. An
     # optional on_save snapshot is taken after a document change.
+    #
+    # Returns an outcome symbol for the reliable-delivery ack: :applied when a
+    # document update was integrated and relayed, :gap when it was rejected for
+    # a resync, :noop for everything else (requests, awareness, empty updates).
     def sync_apply_fast(awareness, encoded, bytes, kind)
       # A document update that isn't causally ready (an earlier one was lost in
       # transit) would relay an un-integrable change to peers and stall the
@@ -214,16 +235,26 @@ module YrbLite
       # the missing piece. See sync_apply_authoritative for the durable variant.
       if kind == MSG_KIND_UPDATE
         update = awareness.update_from_message(bytes)
-        return sync_request_resync(awareness) if update && !awareness.update_ready?(update)
+        # A no-op message (e.g. the empty SyncStep2 in an opening handshake)
+        # carries no change, so there's nothing to relay, persist, or ack.
+        return :noop unless update
+
+        unless awareness.update_ready?(update)
+          sync_request_resync(awareness)
+          return :gap
+        end
       end
 
       response = awareness.handle(bytes)
       sync_transmit(response) unless response.empty?
 
-      return unless [MSG_KIND_UPDATE, MSG_KIND_AWARENESS].include?(kind)
+      return :noop unless [MSG_KIND_UPDATE, MSG_KIND_AWARENESS].include?(kind)
 
       sync_distribute(encoded)
-      sync_persist if kind == MSG_KIND_UPDATE
+      return :noop unless kind == MSG_KIND_UPDATE
+
+      sync_persist
+      :applied
     end
 
     # Authoritative path: record the change durably, then apply it to the
@@ -261,6 +292,11 @@ module YrbLite
       when :recorded then sync_persist
       when :gap      then sync_request_resync(awareness)
       end
+
+      # Surface the outcome for the reliable-delivery ack: :recorded means the
+      # update is durably written (and will be acked); :gap triggered a resync
+      # (no ack); :noop carried no change.
+      outcome
     end
 
     # Ask this connection's client to resync: re-send SyncStep1 carrying the
@@ -269,6 +305,23 @@ module YrbLite
     # delta -- which heals the gap that triggered the resync.
     def sync_request_resync(awareness)
       sync_transmit(awareness.sync_step1)
+    end
+
+    # Reliable delivery: acknowledge an accepted update back to the sending
+    # connection. An ack-aware client tags each outgoing update with an "id"
+    # and retains it until the matching `{ "ack" => id }` returns, retransmitting
+    # on a timer or reconnect; idempotent CRDT apply makes resends free. We ack
+    # only when the client supplied an id (so stock clients are unaffected) and
+    # the update was actually accepted -- recorded in audit mode, applied in fast
+    # mode. A gapped update gets no ack (it got a resync), so the client keeps
+    # retransmitting until the missing range lands and the update can integrate.
+    def sync_send_ack(id, outcome)
+      return if id.nil?
+      return unless %i[recorded applied].include?(outcome)
+
+      # Braces are load-bearing: a bare hash would bind to transmit's `via:`
+      # keyword instead of its positional data argument.
+      transmit({ "ack" => id })
     end
 
     # Single broadcast point for both paths (and presence removal), so the
@@ -343,14 +396,19 @@ module YrbLite
     # changes are recorded durably before relay and then broadcast, and
     # awareness is relayed best-effort. Echoing back to the sender is harmless,
     # since the CRDT apply is idempotent.
+    #
+    # Returns an outcome symbol for the reliable-delivery ack: :recorded when a
+    # document update was durably recorded and relayed, :gap when it was
+    # rejected for a resync, :noop for everything else.
     def sync_receive_store_backed(encoded, bytes)
       case Sync.codec.message_kind(bytes)
       when MSG_KIND_SYNC_STEP1
         result = sync_load_doc.handle_sync_message(bytes)
         sync_transmit(result[2]) if result
+        :noop
       when MSG_KIND_UPDATE
         update = Sync.codec.update_from_message(bytes)
-        return unless update
+        return :noop unless update
 
         # Store mode keeps no warm replica, so to tell whether this update is
         # causally ready we rebuild the doc from the store and check against it.
@@ -359,12 +417,19 @@ module YrbLite
         # its record failed -- is rejected and the client asked to resync,
         # rather than written to the log as a permanently-pending entry.
         doc = sync_load_doc
-        return sync_transmit(doc.sync_step1) unless doc.update_ready?(update)
+        unless doc.update_ready?(update)
+          sync_transmit(doc.sync_step1)
+          return :gap
+        end
 
         self.class.on_change&.call(@sync_key, update) # record before relay
         sync_distribute(encoded)
+        :recorded
       when MSG_KIND_AWARENESS
         sync_distribute(encoded)
+        :noop
+      else
+        :noop
       end
     end
 

--- a/test/sync_test.rb
+++ b/test/sync_test.rb
@@ -532,6 +532,98 @@ class SyncTest < Minitest::Test
                  "replaying the audit log reproduces the authoritative state"
   end
 
+  # -- Reliable delivery (acks) --------------------------------------------
+
+  # A fast-path channel-like object (no on_change) that captures transmits and
+  # distributions. Used to observe acks without touching ActionCable.
+  def fast_helper(key, transmits:, broadcasts:)
+    klass = Class.new do
+      include YrbLite::Sync
+
+      attr_accessor :_t, :_b
+
+      def transmit(data) = @_t << data
+      define_method(:sync_distribute) { |encoded| @_b << encoded }
+    end
+    helper = klass.new
+    helper._t = transmits
+    helper._b = broadcasts
+    helper.instance_variable_set(:@sync_key, key)
+    helper.instance_variable_set(:@sync_origin, "origin-#{key}")
+    helper.instance_variable_set(:@sync_clients, [])
+    helper
+  end
+
+  def acks_in(transmits)
+    transmits.filter_map { |t| t["ack"] if t.is_a?(Hash) && t.key?("ack") }
+  end
+
+  def test_fast_path_acks_an_applied_update_carrying_an_id
+    transmits = []
+    helper = fast_helper("ack-fast", transmits: transmits, broadcasts: [])
+
+    helper.sync_receive(update_message(YjsFixtures::TwoDocsMerged::DOC1_UPDATE).merge("id" => 7))
+
+    assert_equal [7], acks_in(transmits), "an applied update with an id is acked"
+  end
+
+  def test_authoritative_path_acks_a_recorded_update_carrying_an_id
+    transmits = []
+    recorded = []
+    helper = authoritative_helper("ack-auth", broadcasts: []) { |_k, u| recorded << u }
+    helper.define_singleton_method(:transmit) { |data| transmits << data }
+
+    helper.sync_receive(update_message(YjsFixtures::TwoDocsMerged::DOC1_UPDATE).merge("id" => "abc"))
+
+    assert_equal ["abc"], acks_in(transmits), "a recorded update with an id is acked"
+  end
+
+  def test_store_path_acks_a_recorded_update_carrying_an_id
+    transmits = []
+    helper = store_backed_helper(loader: ->(_k) {}, recorder: ->(_k, _u) {},
+                                 transmits: transmits, broadcasts: [])
+    msg = YrbLite::Awareness.new.encode_update(YjsFixtures::TwoDocsMerged::DOC1_UPDATE)
+
+    helper.sync_receive({ "update" => Base64.strict_encode64(msg), "id" => 42 }, "doc-key")
+
+    assert_equal [42], acks_in(transmits), "store mode acks a recorded update with an id"
+  end
+
+  def test_no_ack_without_an_id
+    # Stock clients send no id and must be completely unaffected -- no ack frame.
+    transmits = []
+    helper = fast_helper("no-ack", transmits: transmits, broadcasts: [])
+
+    helper.sync_receive(update_message(YjsFixtures::TwoDocsMerged::DOC1_UPDATE))
+
+    assert_empty acks_in(transmits), "an update without an id is never acked"
+  end
+
+  def test_gapped_update_is_not_acked
+    # A causally-gapped update gets a resync, not an ack, so an ack-aware client
+    # keeps retransmitting until the missing range lands and it can integrate.
+    transmits = []
+    helper = fast_helper("ack-gap", transmits: transmits, broadcasts: [])
+
+    helper.sync_receive(update_message(YjsFixtures::CausalChain::U1).merge("id" => 1)) # ready
+    helper.sync_receive(update_message(YjsFixtures::CausalChain::U3).merge("id" => 2)) # gap
+
+    assert_equal [1], acks_in(transmits),
+                 "only the integrable update is acked; the gapped one is not"
+  end
+
+  def test_no_op_update_is_not_acked
+    # The empty SyncStep2 in an opening handshake carries no change; even with an
+    # id, there's nothing to ack.
+    transmits = []
+    helper = fast_helper("ack-noop", transmits: transmits, broadcasts: [])
+
+    empty = YrbLite::Awareness.new.encode_update(YjsFixtures::EmptyDoc::UPDATE)
+    helper.sync_receive({ "m" => Base64.strict_encode64(empty), "id" => 9 })
+
+    assert_empty acks_in(transmits), "a no-op update is not acked"
+  end
+
   def test_handle_sync_message_returns_tuple
     doc = YrbLite::Doc.new
 


### PR DESCRIPTION
## Problem

The y-websocket protocol is fire-and-forget. If a client's update is lost in transit (flaky socket, a send that never lands) and the client makes no further edits, the server stays idle, never asks anyone to resync, and that edit is gone — even though the client believes it was saved. CRDTs converge the state everyone *has*; they don't recover an update that never arrived.

This is the delivery-layer half of the no-loss guarantee. The recently-merged causal-gap fix made the server *reject* an un-integrable update and ask for a resync; this closes the remaining hole where the lost update has no causally-dependent follow-up to trigger that resync.

## What this adds

**Server (opt-in, self-gating):** when an incoming frame carries an `"id"`, reply `{ "ack": <id> }` once the update is **accepted** — recorded in audit mode, applied in fast mode. A causally-gapped update is *not* acked (it gets a resync instead), so an ack-aware client knows it hasn't landed.

```
client -> server   { "m": "<base64 update>", "id": 42 }
server -> client    { "ack": 42 }
```

The three apply paths (`sync_apply_fast`, `sync_apply_authoritative`, `sync_receive_store_backed`) now return an outcome symbol (`:recorded`/`:applied`/`:gap`/`:noop`) that `sync_receive` turns into an ack. **Stock clients send no `"id"` → never get acks → behave exactly as before.** No config flag.

**Reference client + e2e** (`examples/actioncable-demo/frontend/reliable.mjs`): tags each update with an incrementing id, keeps it in a pending buffer, retransmits on a timer until the ack returns. The test loses an update mid-flight during a simulated outage and recovers it purely by retransmit — no reconnect, no follow-up edit. Wired into CI alongside the audit slice. Passes in both memory and `AUDIT=1` modes.

## Tests

- Ruby unit tests: ack-on-applied (fast), ack-on-recorded (authoritative + store), and no-ack for missing-id / causally-gapped / no-op frames.
- Full suite green (91 runs), rubocop clean, clippy clean, demo e2e + audit + reliable + eslint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)