### PR TITLE
Reliable ActionCable provider (vendor upstream, then augment) + demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,4 @@ jobs:
           PORT=3777 bun audit_scenarios.mjs
           PORT=3777 bun audit.mjs
           PORT=3777 bun reliable.mjs
+          PORT=3777 bun reliable_provider.mjs

--- a/README.md
+++ b/README.md
@@ -320,9 +320,27 @@ and no dependence on a later edit happening to trigger a resync.
 
 This is entirely **self-gating**: stock clients send no `"id"`, so they never get
 acks and behave exactly as before. Only a client that opts in by tagging its
-frames participates. A reference reliable client and an end-to-end test that loses
-an update mid-flight and recovers it purely by retransmit live in
-[`examples/actioncable-demo/frontend/reliable.mjs`](examples/actioncable-demo/frontend/reliable.mjs).
+frames participates.
+
+Two client examples ship in the demo:
+
+- [`frontend/reliable.mjs`](examples/actioncable-demo/frontend/reliable.mjs) — a
+  minimal reference client showing the raw mechanism (tag with an id, retain,
+  retransmit on a timer, drain on ack), with an end-to-end test that loses an
+  update mid-flight and recovers it purely by retransmit.
+- [`frontend/provider/reliable_actioncable_provider.mjs`](examples/actioncable-demo/frontend/provider/reliable_actioncable_provider.mjs)
+  — the standard `@y-rb/actioncable` `WebsocketProvider`, vendored and augmented
+  for production use. It's a drop-in replacement that speaks the same protocol
+  and envelope, and adds reliability with **sync-since-last-ack** framing: rather
+  than retransmitting updates one by one, it keeps the unacknowledged local
+  updates in a queue and sends their *merge* as a single causally-complete delta,
+  with the id being the highest sequence in the batch (so one `{ ack: id }`
+  cumulatively confirms everything up to it). Because the whole unacked tail goes
+  as one self-contained delta, the server never sees an internal gap and never
+  has to round-trip a resync for a lost middle update — the next edit, or the
+  next timer tick, carries it. Awareness stays fire-and-forget; against a server
+  that doesn't implement acks it warns once and falls back to plain delivery; and
+  `reliable: false` opts out entirely. The demo's editor uses this provider.
 
 ### User Awareness/Presence
 

--- a/examples/actioncable-demo/frontend/provider/reliable_actioncable_provider.mjs
+++ b/examples/actioncable-demo/frontend/provider/reliable_actioncable_provider.mjs
@@ -1,7 +1,23 @@
-// Vendored from @y-rb/actioncable (dist/actioncable.esm.js, v0.3.x),
-// detranspiled to readable ESM. This commit is the upstream `WebsocketProvider`
-// with no behavior changes; yrb-lite's reliable-delivery layer is added in the
-// next commit so its diff stands on its own.
+// The @y-rb/actioncable WebsocketProvider, vendored and augmented with
+// yrb-lite's reliable-delivery layer. Everything below the marked sections is
+// upstream (detranspiled from dist/actioncable.esm.js, v0.3.x); the additions
+// give "no acknowledged edit is ever silently lost" without changing the wire
+// protocol or the `{ update: ... }` envelope, so it stays a drop-in replacement.
+//
+// How it works (document updates only):
+//   * Each outgoing batch carries an "id". yrb-lite replies `{ ack: <id> }` once
+//     it has *accepted* the update (recorded in audit mode, applied in fast
+//     mode). A causally-gapped update is not acked -- it gets a resync.
+//   * "Sync since last ack": unacknowledged local updates are kept in a queue
+//     and sent as their MERGE -- one causally-complete delta -- so the server
+//     never sees an internal gap. The id is the highest sequence in the batch,
+//     so a single ack cumulatively confirms everything up to it.
+//   * Retransmit on a timer and on reconnect until the ack lands; idempotent
+//     CRDT apply makes resends free.
+//
+// Awareness/presence stays fire-and-forget (ephemeral, no point acking).
+// Against a server that doesn't implement acks the provider warns once and
+// falls back to plain delivery. `reliable: false` opts out entirely.
 import { writeVarUint, writeVarUint8Array, createEncoder, length, toUint8Array } from "lib0/encoding"
 import { readVarUint8Array, createDecoder, readVarUint } from "lib0/decoding"
 import {
@@ -19,6 +35,7 @@ import {
 } from "y-protocols/awareness"
 import { readAuthMessage } from "y-protocols/auth"
 import { publish, subscribe, unsubscribe } from "lib0/broadcastchannel"
+import * as Y from "yjs" // [reliable] mergeUpdates for sync-since-last-ack
 
 const MessageType = { Sync: 0, Awareness: 1, Auth: 2, QueryAwareness: 3 }
 
@@ -49,7 +66,20 @@ const messageHandlers = {
 }
 
 export class WebsocketProvider {
-  constructor(doc, consumer, channel, params, { awareness = new Awareness(doc), disableBc = false } = {}) {
+  constructor(
+    doc,
+    consumer,
+    channel,
+    params,
+    {
+      awareness = new Awareness(doc),
+      disableBc = false,
+      // [reliable] opt-in delivery guarantee (on by default).
+      reliable = true,
+      resendInterval = 1000,
+      maxUnconfirmedResends = 8,
+    } = {}
+  ) {
     this.consumer = consumer
     this.channel = undefined
     this.params = params
@@ -61,6 +91,17 @@ export class WebsocketProvider {
     this.disableBc = disableBc
     this._synced = false
 
+    // [reliable] delivery state.
+    this.reliable = reliable
+    this.resendInterval = resendInterval
+    this.maxUnconfirmedResends = maxUnconfirmedResends
+    this.pending = [] // unacked local updates: [{ seq, update }], in order
+    this.nextSeq = 1
+    this.everAcked = false
+    this._resendsSinceProgress = 0
+    this._serverConnected = false
+    this._resendTimer = undefined
+
     this.bcSubscriber = (data, origin) => {
       if (origin !== this) {
         const encoder = this.process(new Uint8Array(data), false)
@@ -69,10 +110,17 @@ export class WebsocketProvider {
     }
     this.updateHandler = (update, origin) => {
       if (origin !== this) {
-        const encoder = createEncoder()
-        writeVarUint(encoder, MessageType.Sync)
-        writeUpdate(encoder, update)
-        this.send(toUint8Array(encoder))
+        // [reliable] queue the local update and send the merged unacked tail;
+        // otherwise behave like upstream (one fire-and-forget Sync/Update).
+        if (this.reliable) {
+          this.pending.push({ seq: this.nextSeq++, update })
+          this.flushToServer()
+        } else {
+          const encoder = createEncoder()
+          writeVarUint(encoder, MessageType.Sync)
+          writeUpdate(encoder, update)
+          this.send(toUint8Array(encoder))
+        }
       }
     }
     this.unloadHandler = () => {
@@ -110,11 +158,62 @@ export class WebsocketProvider {
     this.doc.off("update", this.updateHandler)
   }
 
-  send(buffer, { whisper = false } = {}) {
+  send(buffer, { whisper = false, id = undefined } = {}) {
     const update = encodeBinaryToBase64(buffer)
-    if (whisper && hasWhisper(this.channel)) this.channel.whisper({ update })
-    else this.channel?.send({ update })
+    // [reliable] include the batch id when present so the server can ack it.
+    const payload = id === undefined ? { update } : { update, id }
+    if (whisper && hasWhisper(this.channel)) this.channel.whisper(payload)
+    else this.channel?.send(payload)
     if (this.bcconnected) publish(this.bcChannelName, buffer, this)
+  }
+
+  // [reliable] Send the whole unacked tail as one merged delta (sync since last
+  // ack). The id is the highest queued sequence, so one ack confirms the batch.
+  flushToServer() {
+    if (this.pending.length === 0) return
+    const merged = Y.mergeUpdates(this.pending.map((p) => p.update))
+    const id = this.pending[this.pending.length - 1].seq
+    const encoder = createEncoder()
+    writeVarUint(encoder, MessageType.Sync)
+    writeUpdate(encoder, merged)
+    this.send(toUint8Array(encoder), { id })
+  }
+
+  // [reliable] A `{ ack: id }` cumulatively confirms every queued update <= id.
+  onAck(id) {
+    this.everAcked = true
+    this._resendsSinceProgress = 0
+    this.pending = this.pending.filter((p) => p.seq > id)
+  }
+
+  // [reliable] Periodic resend of the unacked tail while connected. The first
+  // round-trip sets everAcked; if we keep resending on a live connection and
+  // never get an ack, the server doesn't support them, so warn once and fall
+  // back to fire-and-forget rather than loop forever.
+  onResendTick() {
+    if (!this._serverConnected || this.pending.length === 0) return
+    if (!this.everAcked && ++this._resendsSinceProgress > this.maxUnconfirmedResends) {
+      console.warn(
+        `[reliable] no acks from ${this.channelName} after ${this.maxUnconfirmedResends} ` +
+          "resends; server appears not to support reliable delivery. Falling back."
+      )
+      this.reliable = false
+      this.pending = []
+      this.stopResendTimer()
+      return
+    }
+    this.flushToServer()
+  }
+
+  startResendTimer() {
+    if (this._resendTimer || !this.reliable) return
+    this._resendTimer = setInterval(() => this.onResendTick(), this.resendInterval)
+    if (typeof this._resendTimer?.unref === "function") this._resendTimer.unref()
+  }
+
+  stopResendTimer() {
+    if (this._resendTimer) clearInterval(this._resendTimer)
+    this._resendTimer = undefined
   }
 
   process(buffer, emitSynced) {
@@ -134,6 +233,11 @@ export class WebsocketProvider {
       { channel: this.channelName, ...this.params },
       {
         received(message) {
+          // [reliable] a delivery ack confirms and prunes the local queue.
+          if (message?.ack !== undefined) {
+            provider.onAck(message.ack)
+            return
+          }
           const encodedUpdate = message.update
           const update = decodeBase64ToBinary(encodedUpdate)
           const encoder = provider.process(update, true)
@@ -141,6 +245,8 @@ export class WebsocketProvider {
         },
         disconnected() {
           provider.synced = false
+          provider._serverConnected = false // [reliable]
+          provider.stopResendTimer() // [reliable] (queue is kept for reconnect)
           // update awareness (all users except local left)
           removeAwarenessStates(
             provider.awareness,
@@ -149,6 +255,7 @@ export class WebsocketProvider {
           )
         },
         connected() {
+          provider._serverConnected = true // [reliable]
           // always send sync step 1 when connected
           const encoder = createEncoder()
           writeVarUint(encoder, MessageType.Sync)
@@ -164,6 +271,9 @@ export class WebsocketProvider {
             )
             provider.send(toUint8Array(encoderAwarenessState))
           }
+          // [reliable] resend any unacked tail and (re)start the resend timer.
+          provider.flushToServer()
+          provider.startResendTimer()
         },
       }
     )
@@ -209,6 +319,8 @@ export class WebsocketProvider {
   }
 
   disconnect() {
+    this.stopResendTimer() // [reliable]
+    this._serverConnected = false // [reliable]
     this.disconnectBc()
     this.channel?.unsubscribe()
     if (this.channel != null) this.channel = undefined
@@ -233,3 +345,7 @@ function decodeBase64ToBinary(update) {
 function hasWhisper(channel) {
   return channel !== undefined && "whisper" in channel && typeof channel.whisper === "function"
 }
+
+// [reliable] Preferred name for the augmented provider. `WebsocketProvider`
+// stays exported so it remains a drop-in for code importing the upstream name.
+export { WebsocketProvider as ReliableActionCableProvider }

--- a/examples/actioncable-demo/frontend/provider/reliable_actioncable_provider.mjs
+++ b/examples/actioncable-demo/frontend/provider/reliable_actioncable_provider.mjs
@@ -1,0 +1,235 @@
+// Vendored from @y-rb/actioncable (dist/actioncable.esm.js, v0.3.x),
+// detranspiled to readable ESM. This commit is the upstream `WebsocketProvider`
+// with no behavior changes; yrb-lite's reliable-delivery layer is added in the
+// next commit so its diff stands on its own.
+import { writeVarUint, writeVarUint8Array, createEncoder, length, toUint8Array } from "lib0/encoding"
+import { readVarUint8Array, createDecoder, readVarUint } from "lib0/decoding"
+import {
+  readSyncMessage,
+  messageYjsSyncStep2,
+  writeSyncStep1,
+  writeSyncStep2,
+  writeUpdate,
+} from "y-protocols/sync"
+import {
+  encodeAwarenessUpdate,
+  applyAwarenessUpdate,
+  removeAwarenessStates,
+  Awareness,
+} from "y-protocols/awareness"
+import { readAuthMessage } from "y-protocols/auth"
+import { publish, subscribe, unsubscribe } from "lib0/broadcastchannel"
+
+const MessageType = { Sync: 0, Awareness: 1, Auth: 2, QueryAwareness: 3 }
+
+const permissionDeniedHandler = (provider, reason) =>
+  console.warn(`Permission denied to access ${provider.channelName}.\n${reason}`)
+
+const messageHandlers = {
+  [MessageType.Sync]: (encoder, decoder, provider, emitSynced) => {
+    writeVarUint(encoder, MessageType.Sync)
+    const syncMessageType = readSyncMessage(decoder, encoder, provider.doc, provider)
+    if (emitSynced && syncMessageType === messageYjsSyncStep2 && !provider.synced) {
+      provider.synced = true
+    }
+  },
+  [MessageType.QueryAwareness]: (encoder, _decoder, provider) => {
+    writeVarUint(encoder, MessageType.Awareness)
+    writeVarUint8Array(
+      encoder,
+      encodeAwarenessUpdate(provider.awareness, Array.from(provider.awareness.getStates().keys()))
+    )
+  },
+  [MessageType.Awareness]: (_encoder, decoder, provider) => {
+    applyAwarenessUpdate(provider.awareness, readVarUint8Array(decoder), provider)
+  },
+  [MessageType.Auth]: (_encoder, decoder, provider) => {
+    readAuthMessage(decoder, provider.doc, (_ydoc, reason) => permissionDeniedHandler(provider, reason))
+  },
+}
+
+export class WebsocketProvider {
+  constructor(doc, consumer, channel, params, { awareness = new Awareness(doc), disableBc = false } = {}) {
+    this.consumer = consumer
+    this.channel = undefined
+    this.params = params
+    this.doc = doc
+    this.channelName = channel
+    this.bcChannelName = `${channel}_${Object.entries(params).map((k, v) => `${k}-${v}`).join("_")}`
+    this.awareness = awareness
+    this.bcconnected = false
+    this.disableBc = disableBc
+    this._synced = false
+
+    this.bcSubscriber = (data, origin) => {
+      if (origin !== this) {
+        const encoder = this.process(new Uint8Array(data), false)
+        if (length(encoder) > 1) publish(this.bcChannelName, toUint8Array(encoder), this)
+      }
+    }
+    this.updateHandler = (update, origin) => {
+      if (origin !== this) {
+        const encoder = createEncoder()
+        writeVarUint(encoder, MessageType.Sync)
+        writeUpdate(encoder, update)
+        this.send(toUint8Array(encoder))
+      }
+    }
+    this.unloadHandler = () => {
+      removeAwarenessStates(this.awareness, [this.doc.clientID], "window unload")
+    }
+    this.awarenessUpdateHandler = ({ added, updated, removed }) => {
+      const changedClients = added.concat(updated).concat(removed)
+      const encoder = createEncoder()
+      writeVarUint(encoder, MessageType.Awareness)
+      writeVarUint8Array(encoder, encodeAwarenessUpdate(this.awareness, changedClients))
+      this.send(toUint8Array(encoder), { whisper: true })
+    }
+
+    this.doc.on("update", this.updateHandler)
+    if (typeof window !== "undefined") window.addEventListener("unload", this.unloadHandler)
+    else if (typeof process !== "undefined") process.on("exit", this.unloadHandler)
+    this.awareness.on("update", this.awarenessUpdateHandler)
+
+    this.connect()
+  }
+
+  get synced() {
+    return this._synced
+  }
+
+  set synced(state) {
+    if (this._synced !== state) this._synced = state
+  }
+
+  destroy() {
+    this.disconnect()
+    if (typeof window !== "undefined") window.removeEventListener("unload", this.unloadHandler)
+    else if (typeof process !== "undefined") process.off("exit", this.unloadHandler)
+    this.awareness.off("update", this.awarenessUpdateHandler)
+    this.doc.off("update", this.updateHandler)
+  }
+
+  send(buffer, { whisper = false } = {}) {
+    const update = encodeBinaryToBase64(buffer)
+    if (whisper && hasWhisper(this.channel)) this.channel.whisper({ update })
+    else this.channel?.send({ update })
+    if (this.bcconnected) publish(this.bcChannelName, buffer, this)
+  }
+
+  process(buffer, emitSynced) {
+    const decoder = createDecoder(buffer)
+    const encoder = createEncoder()
+    const messageType = readVarUint(decoder)
+    const messageHandler = messageHandlers[messageType]
+    if (messageHandler) messageHandler(encoder, decoder, this, emitSynced, messageType)
+    else console.error("Unable to compute message")
+    return encoder
+  }
+
+  subscribe() {
+    const provider = this
+    this.synced = false
+    this.channel = this.consumer.subscriptions.create(
+      { channel: this.channelName, ...this.params },
+      {
+        received(message) {
+          const encodedUpdate = message.update
+          const update = decodeBase64ToBinary(encodedUpdate)
+          const encoder = provider.process(update, true)
+          if (length(encoder) > 1) provider.send(toUint8Array(encoder))
+        },
+        disconnected() {
+          provider.synced = false
+          // update awareness (all users except local left)
+          removeAwarenessStates(
+            provider.awareness,
+            Array.from(provider.awareness.getStates().keys()).filter((client) => client !== provider.doc.clientID),
+            provider
+          )
+        },
+        connected() {
+          // always send sync step 1 when connected
+          const encoder = createEncoder()
+          writeVarUint(encoder, MessageType.Sync)
+          writeSyncStep1(encoder, provider.doc)
+          provider.send(toUint8Array(encoder))
+          // broadcast local awareness state
+          if (provider.awareness.getLocalState() !== null) {
+            const encoderAwarenessState = createEncoder()
+            writeVarUint(encoderAwarenessState, MessageType.Awareness)
+            writeVarUint8Array(
+              encoderAwarenessState,
+              encodeAwarenessUpdate(provider.awareness, [provider.doc.clientID])
+            )
+            provider.send(toUint8Array(encoderAwarenessState))
+          }
+        },
+      }
+    )
+  }
+
+  connectBc() {
+    if (this.disableBc) return
+    if (!this.bcconnected) {
+      subscribe(this.bcChannelName, this.bcSubscriber)
+      this.bcconnected = true
+    }
+    // send sync step 1 to bc
+    const encoderSync = createEncoder()
+    writeVarUint(encoderSync, MessageType.Sync)
+    writeSyncStep1(encoderSync, this.doc)
+    publish(this.bcChannelName, toUint8Array(encoderSync), this)
+    // broadcast local state
+    const encoderState = createEncoder()
+    writeVarUint(encoderState, MessageType.Sync)
+    writeSyncStep2(encoderState, this.doc)
+    publish(this.bcChannelName, toUint8Array(encoderState), this)
+    // write queryAwareness
+    const encoderAwarenessQuery = createEncoder()
+    writeVarUint(encoderAwarenessQuery, MessageType.QueryAwareness)
+    publish(this.bcChannelName, toUint8Array(encoderAwarenessQuery), this)
+    // broadcast local awareness state
+    const encoderAwarenessState = createEncoder()
+    writeVarUint(encoderAwarenessState, MessageType.Awareness)
+    writeVarUint8Array(encoderAwarenessState, encodeAwarenessUpdate(this.awareness, [this.doc.clientID]))
+    publish(this.bcChannelName, toUint8Array(encoderAwarenessState), this)
+  }
+
+  disconnectBc() {
+    // broadcast message with local awareness state set to null (indicating disconnect)
+    const encoder = createEncoder()
+    writeVarUint(encoder, MessageType.Awareness)
+    writeVarUint8Array(encoder, encodeAwarenessUpdate(this.awareness, [this.doc.clientID], new Map()))
+    this.send(toUint8Array(encoder))
+    if (this.bcconnected) {
+      unsubscribe(this.bcChannelName, this.bcSubscriber)
+      this.bcconnected = false
+    }
+  }
+
+  disconnect() {
+    this.disconnectBc()
+    this.channel?.unsubscribe()
+    if (this.channel != null) this.channel = undefined
+  }
+
+  connect() {
+    if (this.channel == null) {
+      this.subscribe()
+      this.connectBc()
+    }
+  }
+}
+
+function encodeBinaryToBase64(bin) {
+  return btoa(Array.from(bin, (ch) => String.fromCharCode(ch)).join(""))
+}
+
+function decodeBase64ToBinary(update) {
+  return Uint8Array.from(atob(update), (c) => c.charCodeAt(0))
+}
+
+function hasWhisper(channel) {
+  return channel !== undefined && "whisper" in channel && typeof channel.whisper === "function"
+}

--- a/examples/actioncable-demo/frontend/reliable_provider.mjs
+++ b/examples/actioncable-demo/frontend/reliable_provider.mjs
@@ -1,0 +1,165 @@
+// Drives the vendored ReliableActionCableProvider against the yrb-lite server,
+// headless. Two checks:
+//
+//   1. Compatibility: two reliable providers sync documents + presence exactly
+//      like the stock @y-rb/actioncable provider does.
+//   2. Reliability: a silently-lost client->server batch is recovered by the
+//      provider's own retransmit -- no reconnect, no follow-up edit -- and the
+//      ack drains its pending queue.
+//
+//   bin/rails s -p 3777        (AUDIT=1 also works)
+//   cd frontend && bun reliable_provider.mjs
+//
+// Like provider_check.mjs, we hand the provider a minimal raw-WebSocket
+// ActionCable consumer (the browser transport doesn't deliver inbound messages
+// headless). The consumer has a `blackhole` switch that drops outbound frames
+// without tearing down the socket -- a lost-in-transit network, not a
+// disconnect -- so the provider keeps retransmitting on its timer.
+import * as Y from "yjs"
+import { ReliableActionCableProvider } from "./provider/reliable_actioncable_provider.mjs"
+
+const PORT = process.env.PORT || 3777
+const ROOM = `relprov-${process.pid}`
+const URL = `ws://localhost:${PORT}/cable`
+
+// Minimal ActionCable consumer over a raw WebSocket, with a network blackhole.
+function rawConsumer(url) {
+  const subs = []
+  let welcomed = false
+  const state = { blackhole: false, dropped: 0 }
+  const ws = new WebSocket(url, ["actioncable-v1-json"])
+  const subscribe = (s) => ws.send(JSON.stringify({ command: "subscribe", identifier: s.identifier }))
+  ws.onmessage = (e) => {
+    const msg = JSON.parse(e.data)
+    if (msg.type === "welcome") {
+      welcomed = true
+      subs.forEach(subscribe)
+    } else if (msg.type === "confirm_subscription") {
+      subs.find((s) => s.identifier === msg.identifier)?.connected?.()
+    } else if (msg.message) {
+      subs.find((s) => s.identifier === msg.identifier)?.received?.(msg.message)
+    }
+  }
+  return {
+    state,
+    subscriptions: {
+      create(params, mixin) {
+        const identifier = JSON.stringify(params)
+        const sub = Object.assign(
+          {
+            identifier,
+            send(data) {
+              if (state.blackhole) {
+                state.dropped++ // simulate a frame lost in transit
+                return true
+              }
+              ws.send(JSON.stringify({ command: "message", identifier, data: JSON.stringify(data) }))
+              return true
+            },
+            unsubscribe() {
+              ws.send(JSON.stringify({ command: "unsubscribe", identifier }))
+            },
+          },
+          mixin
+        )
+        subs.push(sub)
+        if (welcomed && ws.readyState === WebSocket.OPEN) subscribe(sub)
+        return sub
+      },
+    },
+  }
+}
+
+let failures = 0
+const check = (label, ok) => {
+  console.log(`${ok ? "ok" : "FAIL"}: ${label}`)
+  if (!ok) failures++
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+const waitFor = async (label, pred, ms = 5000) => {
+  const end = Date.now() + ms
+  while (Date.now() < end) {
+    if (pred()) return true
+    await sleep(50)
+  }
+  check(`TIMEOUT: ${label}`, false)
+  return false
+}
+const stayFalse = async (label, pred, ms = 600) => {
+  const end = Date.now() + ms
+  while (Date.now() < end) {
+    if (pred()) {
+      check(`${label} (unexpectedly true)`, false)
+      return false
+    }
+    await sleep(50)
+  }
+  return true
+}
+const addParagraph = (doc, t) => {
+  const frag = doc.getXmlFragment("default")
+  doc.transact(() => {
+    const p = new Y.XmlElement("paragraph")
+    p.insert(0, [new Y.XmlText(t)])
+    frag.insert(frag.length, [p])
+  })
+}
+const text = (doc) => doc.getXmlFragment("default").toString()
+
+const opts = { disableBc: true, resendInterval: 150 }
+const doc1 = new Y.Doc()
+const doc2 = new Y.Doc()
+const c1 = rawConsumer(URL)
+const p1 = new ReliableActionCableProvider(doc1, c1, "DocumentChannel", { id: ROOM }, opts)
+const p2 = new ReliableActionCableProvider(doc2, rawConsumer(URL), "DocumentChannel", { id: ROOM }, opts)
+
+await waitFor("both providers report synced", () => p1.synced && p2.synced)
+check("both providers synced with the server", p1.synced && p2.synced)
+
+// 1. Normal edit: propagates, gets acked, drains p1's pending queue.
+addParagraph(doc1, "alpha")
+await waitFor("p2 receives alpha", () => text(doc2).includes("alpha"))
+await waitFor("p1's queue drains (alpha acked)", () => p1.pending.length === 0)
+check("normal edit acked and propagated", text(doc2).includes("alpha") && p1.everAcked)
+
+// 2. Network blackhole: p1's next batch (and every retransmit) is dropped before
+//    reaching the server. Nothing else is sent, so the server stays idle and
+//    never asks anyone to resync -- a plain provider would lose this edit.
+c1.state.blackhole = true
+addParagraph(doc1, "beta-lost")
+
+const absent = await stayFalse("beta-lost stays off p2 during the outage", () =>
+  text(doc2).includes("beta-lost")
+)
+check("lost edit did not reach p2 during the outage", absent)
+check("p1 still has the edit queued (unacked)", p1.pending.length > 0)
+check("the provider kept retransmitting (and failing)", c1.state.dropped >= 2)
+
+// 3. Connectivity returns: the next retransmit lands, the server acks, and the
+//    edit propagates. Recovery is driven purely by the provider's retransmit.
+c1.state.blackhole = false
+await waitFor("p1's queue drains once connectivity returns", () => p1.pending.length === 0)
+await waitFor("p2 receives the recovered beta-lost", () => text(doc2).includes("beta-lost"))
+check("retransmit recovered the lost edit", text(doc2).includes("beta-lost") && p1.pending.length === 0)
+
+// Presence still flows, and the docs converge byte-for-byte.
+p1.awareness.setLocalState({ user: { name: "P-ONE" } })
+await waitFor("p2 sees p1's presence", () =>
+  [...p2.awareness.getStates().values()].some((s) => s.user?.name === "P-ONE")
+)
+check("awareness propagated", [...p2.awareness.getStates().values()].some((s) => s.user?.name === "P-ONE"))
+
+await sleep(200)
+const a = Y.encodeStateAsUpdate(doc1)
+const b = Y.encodeStateAsUpdate(doc2)
+check("documents converged byte-for-byte", a.length === b.length && a.every((x, i) => x === b[i]))
+
+p1.destroy()
+p2.destroy()
+console.log("")
+if (failures > 0) {
+  console.log(`FAILED: ${failures} check(s) failed`)
+  process.exit(1)
+}
+console.log(`PASS: room ${ROOM} (provider recovered a silently-lost batch via retransmit)`)
+process.exit(0)

--- a/examples/actioncable-demo/frontend/src/app.js
+++ b/examples/actioncable-demo/frontend/src/app.js
@@ -1,6 +1,6 @@
 import * as Y from "yjs"
 import { createConsumer } from "@rails/actioncable"
-import { WebsocketProvider } from "@y-rb/actioncable"
+import { ReliableActionCableProvider } from "../provider/reliable_actioncable_provider.mjs"
 import { Editor } from "@tiptap/core"
 import StarterKit from "@tiptap/starter-kit"
 import Collaboration from "@tiptap/extension-collaboration"
@@ -18,13 +18,15 @@ const user = {
   color: COLORS[Math.floor(Math.random() * COLORS.length)],
 }
 
-// The standard y-rb provider speaks the y-websocket protocol over an
-// ActionCable subscription, with no hand-rolled provider. yrb-lite's server
-// (YrbLite::Sync) is wire-compatible with it: it accepts the `{ update: ... }`
-// envelope and sends one protocol message per frame.
+// The reliable provider is the standard @y-rb/actioncable WebsocketProvider
+// (wire-compatible with yrb-lite's server: the `{ update: ... }` envelope, one
+// protocol message per frame) augmented with ack-based delivery. It tags each
+// batch with an id, retains the unacked tail, and retransmits until the server
+// acks -- so an edit can't be silently lost on a flaky connection. Pass
+// `reliable: false` to fall back to the stock provider behavior.
 const ydoc = new Y.Doc()
 const consumer = createConsumer()
-const provider = new WebsocketProvider(ydoc, consumer, "DocumentChannel", { id: documentId })
+const provider = new ReliableActionCableProvider(ydoc, consumer, "DocumentChannel", { id: documentId })
 
 statusEl.dataset.state = "connecting"
 statusEl.textContent = `connecting as ${user.name}…`


### PR DESCRIPTION
Follow-up to #3 (server acks + minimal reference client). This adds the **production-grade client** — the standard `@y-rb/actioncable` `WebsocketProvider`, vendored and augmented with reliable delivery — and switches the demo editor to it.

Structured as three commits so the augmentation is reviewable on its own:

1. **Vendor the @y-rb/actioncable WebsocketProvider** — detranspiled from `dist/actioncable.esm.js` (v0.3.x) to readable ESM, **no behavior changes**. This is the upstream baseline.
2. **Augment with reliable delivery** — the diff here is exactly the reliability layer (every added line marked `[reliable]`).
3. **Switch the demo editor** to the provider so the live app exercises acks.

## Sync-since-last-ack

Instead of retransmitting updates one at a time, the provider keeps the unacknowledged local updates in a queue and sends their **merge** as a single causally-complete delta, with the id set to the highest sequence in the batch. One `{ ack: id }` cumulatively confirms everything `<= id`. Because the whole unacked tail ships as one self-contained delta, the server never sees an internal gap and never has to round-trip a resync for a lost *middle* update — the next edit (or timer tick) carries it. In steady state each batch is just the one new update, so it's nearly free.

## Scope / safety

- **Document updates** reliable; **awareness/presence** unchanged (fire-and-forget).
- **Cross-tab BroadcastChannel** sync preserved from upstream.
- **Graceful fallback**: against a server that never acks, it warns once and reverts to plain delivery (no infinite resend loop).
- **Opt-out**: `reliable: false` behaves exactly like upstream. Exported as `ReliableActionCableProvider`, with `WebsocketProvider` kept as a drop-in alias.

## Tests

`reliable_provider.mjs` drives the provider headless through a raw-WebSocket consumer (same harness as `provider_check.mjs`) with a **network blackhole** toggle — drops outbound frames without tearing down the socket. Verifies compatible doc + presence sync, a silently-lost batch recovered purely by the provider's retransmit (no reconnect, no follow-up edit), and byte-for-byte convergence. Full smoke slice green in both memory and `AUDIT=1` modes; the demo bundle builds; eslint clean. Wired into CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)