### PR TITLE
Extract ActionCable integration into yrb-lite-actioncable

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,3 +63,4 @@ Gemspec/DevelopmentDependencies:
 Naming/FileName:
   Exclude:
     - "lib/yrb-lite.rb"
+    - "lib/yrb-lite-actioncable.rb"

--- a/CHANGELOG-actioncable.md
+++ b/CHANGELOG-actioncable.md
@@ -1,0 +1,26 @@
+# Changelog — yrb-lite-actioncable
+
+All notable changes to the `yrb-lite-actioncable` gem are documented here. The
+format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
+this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0.beta1] - 2026-06-18
+
+### Added
+
+- Initial release, extracted from `yrb-lite` (which shipped this as
+  `YrbLite::Sync` through 0.1.0.beta4). Provides `YrbLite::ActionCable::Sync`, an
+  ActionCable channel concern implementing the y-websocket sync protocol and
+  awareness/presence over ActionCable and AnyCable: record-before-distribute
+  auditing (`on_change`), persistence hooks (`on_load`/`on_save`), `:memory` and
+  `:store` backends, presence reaping, idle-document eviction, and multi-process
+  replica sync. Depends on `yrb-lite` (>= 0.1.0.beta5) for the CRDT documents,
+  awareness, and protocol primitives.
+- `on_change` recorders run in the channel instance's context (carried over from
+  `yrb-lite` 0.1.0.beta4), so a recorder can call the channel's own methods
+  directly.
+
+[Unreleased]: https://github.com/jpcamara/yrb-lite/commits/main
+[0.1.0.beta1]: https://github.com/jpcamara/yrb-lite/releases/tag/v0.1.0.beta5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.0.beta5] - 2026-06-18
+
+### Changed
+
+- **Breaking:** the ActionCable integration has been extracted into a separate
+  gem, [`yrb-lite-actioncable`](https://rubygems.org/gems/yrb-lite-actioncable).
+  `yrb-lite` is now a standalone y-crdt wrapper: CRDT documents, awareness, and
+  the y-websocket sync protocol primitives, with no Rails/ActionCable coupling
+  (mirrors the `y-rb` / `yrb-actioncable` split). The `base64` runtime
+  dependency moved with it.
+
+### Migration
+
+- Using `YrbLite::Sync`? Add `gem "yrb-lite-actioncable"` and change
+  `include YrbLite::Sync` to `include YrbLite::ActionCable::Sync`. The concern's
+  API is otherwise unchanged. If you only use `YrbLite::Doc`/`YrbLite::Awareness`,
+  nothing changes.
+
 ## [0.1.0.beta4] - 2026-06-18
 
 ### Changed
@@ -91,7 +109,8 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Precompiled native gems for common platforms (no Rust toolchain needed to
   install) via the cross-gem workflow.
 
-[Unreleased]: https://github.com/jpcamara/yrb-lite/compare/v0.1.0.beta4...main
+[Unreleased]: https://github.com/jpcamara/yrb-lite/compare/v0.1.0.beta5...main
+[0.1.0.beta5]: https://github.com/jpcamara/yrb-lite/compare/v0.1.0.beta4...v0.1.0.beta5
 [0.1.0.beta4]: https://github.com/jpcamara/yrb-lite/compare/v0.1.0.beta3...v0.1.0.beta4
 [0.1.0.beta3]: https://github.com/jpcamara/yrb-lite/compare/v0.1.0.beta2...v0.1.0.beta3
 [0.1.0.beta2]: https://github.com/jpcamara/yrb-lite/compare/v0.1.0.beta1...v0.1.0.beta2

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@
 
 source "https://rubygems.org"
 
-gemspec
+gemspec name: "yrb-lite"
+gemspec name: "yrb-lite-actioncable"
 
 gem "rake-compiler"
 gem "rb_sys"

--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,27 @@
 # frozen_string_literal: true
 
-require "bundler/gem_tasks"
+require "bundler"
 require "rake/testtask"
 require "rake/extensiontask"
 require "rb_sys/extensiontask"
+
+# This repo ships two gems (core `yrb-lite` + `yrb-lite-actioncable`), so the
+# default bundler/gem_tasks can't auto-pick a gemspec. Scope build/release/install
+# to the core gem; the pure-Ruby actioncable gem builds via `rake actioncable:build`.
+Bundler::GemHelper.install_tasks(name: "yrb-lite")
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/*_test.rb"]
+end
+
+desc "Build the yrb-lite-actioncable gem into pkg/"
+task "actioncable:build" do
+  require_relative "lib/yrb_lite/action_cable/version"
+  mkdir_p "pkg"
+  sh "gem build yrb-lite-actioncable.gemspec --output " \
+     "pkg/yrb-lite-actioncable-#{YrbLite::ActionCable::VERSION}.gem"
 end
 
 # Passing the gemspec registers the cross-compilation tasks

--- a/Rakefile
+++ b/Rakefile
@@ -24,6 +24,35 @@ task "actioncable:build" do
      "pkg/yrb-lite-actioncable-#{YrbLite::ActionCable::VERSION}.gem"
 end
 
+namespace :release do
+  desc "Print the two-gem release sequence (core via precompiled CI; actioncable pure Ruby)"
+  task :steps do
+    require_relative "lib/yrb_lite/version"
+    require_relative "lib/yrb_lite/action_cable/version"
+    core = YrbLite::VERSION
+    cable = YrbLite::ActionCable::VERSION
+    puts <<~STEPS
+      This repo ships TWO gems. Release them together when the shared core API changes.
+      JP runs the `gem push`/`git push` steps (RubyGems MFA + the default-branch guard).
+
+      1) yrb-lite #{core}  — core, native extension; precompiled platform gems via CI
+         a. bump lib/yrb_lite/version.rb + CHANGELOG.md, then commit
+         b. git tag v#{core} && git push origin main "v#{core}"
+         c. the "Precompiled gems" workflow builds 8 platform gems + the source gem
+         d. gh run download <run-id> --dir tmp/ ; cp tmp/**/*.gem pkg/
+         e. gem push pkg/yrb-lite-#{core}*.gem        # 9 gems: source + 8 platforms
+
+      2) yrb-lite-actioncable #{cable}  — pure Ruby; one gem, no precompilation
+         a. bump lib/yrb_lite/action_cable/version.rb + CHANGELOG-actioncable.md, commit
+         b. rake actioncable:build
+         c. gem push pkg/yrb-lite-actioncable-#{cable}.gem
+
+      The actioncable gem depends on `yrb-lite >= 0.1.0.beta5` (a floor, so it tolerates
+      newer core releases); only raise it when it needs a newer core API.
+    STEPS
+  end
+end
+
 # Passing the gemspec registers the cross-compilation tasks
 # (`native:<platform> gem`) that the precompiled-gem build relies on.
 GEMSPEC = Gem::Specification.load("yrb-lite.gemspec")

--- a/examples/actioncable-demo/Gemfile
+++ b/examples/actioncable-demo/Gemfile
@@ -30,6 +30,7 @@ group :development do
 end
 
 gem "yrb-lite", path: "../.."
+gem "yrb-lite-actioncable", path: "../.."
 
 # AnyCable (multi-process WebSocket server) — for the AnyCable harness/test
 gem "anycable-rails", "~> 1.6"

--- a/examples/actioncable-demo/app/channels/document_channel.rb
+++ b/examples/actioncable-demo/app/channels/document_channel.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 # Collaborative document channel. The whole y-websocket protocol is the three
-# lines of YrbLite::Sync below. Documents live in memory; add on_load/on_save
-# callbacks to persist them.
+# lines of YrbLite::ActionCable::Sync below. Documents live in memory; add
+# on_load/on_save callbacks to persist them.
 class DocumentChannel < ApplicationCable::Channel
-  include YrbLite::Sync
+  include YrbLite::ActionCable::Sync
 
   # Opt-in audit mode (AUDIT=1): record every change durably, in a single total
   # order, before it's applied or broadcast. Without it, the channel uses the

--- a/examples/actioncable-demo/app/controllers/documents_controller.rb
+++ b/examples/actioncable-demo/app/controllers/documents_controller.rb
@@ -20,7 +20,7 @@ class DocumentsController < ApplicationController
       if ENV["AUDIT"].present?
         Store.current.replay(params[:id])
       else
-        YrbLite::Sync.registry[params[:id]]&.encode_state_as_update
+        YrbLite::ActionCable::Sync.registry[params[:id]]&.encode_state_as_update
       end
     return render json: { error: "No such document" }, status: :not_found unless update
 

--- a/ext/yrb_lite/src/lib.rs
+++ b/ext/yrb_lite/src/lib.rs
@@ -1,10 +1,10 @@
 use magnus::{function, method, prelude::*, Error, RString, Ruby, TryConvert, Value};
+use std::sync::Mutex;
 use yrs::encoding::read::{Cursor, Read};
 use yrs::sync::protocol::MessageReader;
 use yrs::sync::{Awareness, DefaultProtocol, Message, Protocol, SyncMessage};
 use yrs::updates::decoder::{Decode, DecoderV1};
 use yrs::updates::encoder::{Encode, Encoder, EncoderV1};
-use std::sync::Mutex;
 use yrs::{ClientID, Doc, ReadTxn, Transact};
 
 /// Wrapper around yrs Doc.

--- a/lib/yrb-lite-actioncable.rb
+++ b/lib/yrb-lite-actioncable.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Entry point matching the gem name, so `Bundler.require` works out of the box.
+require "yrb_lite/action_cable"

--- a/lib/yrb_lite.rb
+++ b/lib/yrb_lite.rb
@@ -13,8 +13,8 @@ rescue LoadError
 end
 
 module YrbLite
-  # Error class is defined in Rust extension
-
-  # Autoload Sync module - only loaded when ActionCable is available
-  autoload :Sync, "yrb_lite/sync"
+  # Error class is defined in the Rust extension.
+  #
+  # The ActionCable integration (YrbLite::ActionCable::Sync) lives in the
+  # separate `yrb-lite-actioncable` gem; require "yrb_lite/action_cable".
 end

--- a/lib/yrb_lite/action_cable.rb
+++ b/lib/yrb_lite/action_cable.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "yrb_lite"
+require "yrb_lite/action_cable/version"
+
+module YrbLite
+  # ActionCable integration for yrb-lite.
+  #
+  # Provides YrbLite::ActionCable::Sync, a channel concern implementing the
+  # y-websocket sync protocol and awareness/presence over ActionCable (and
+  # AnyCable), so a Rails app can be the collaboration server for Y.js editors
+  # with no Node sidecar. The CRDT documents, awareness, and protocol primitives
+  # themselves come from the core `yrb-lite` gem.
+  module ActionCable
+  end
+end
+
+require "yrb_lite/action_cable/sync"

--- a/lib/yrb_lite/action_cable/sync.rb
+++ b/lib/yrb_lite/action_cable/sync.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
+require "yrb_lite"
 require "base64"
 require "securerandom"
 
-module YrbLite
+module YrbLite::ActionCable # rubocop:disable Style/ClassAndModuleChildren
   # y-websocket protocol over ActionCable.
   #
   # Include this module in an ActionCable channel to sync Y.js documents
@@ -15,7 +16,7 @@ module YrbLite
   #
   # Example:
   #   class DocumentChannel < ApplicationCable::Channel
-  #     include YrbLite::Sync
+  #     include YrbLite::ActionCable::Sync
   #
   #     on_load { |key| Document.find_by(key: key)&.content }
   #     on_save { |key, update| Document.find_by(key: key)&.update!(content: update) }

--- a/lib/yrb_lite/action_cable/version.rb
+++ b/lib/yrb_lite/action_cable/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module YrbLite
+  module ActionCable
+    VERSION = "0.1.0.beta1"
+  end
+end

--- a/lib/yrb_lite/version.rb
+++ b/lib/yrb_lite/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module YrbLite
-  VERSION = "0.1.0.beta4"
+  VERSION = "0.1.0.beta5"
 end

--- a/test/sync_test.rb
+++ b/test/sync_test.rb
@@ -2,28 +2,28 @@
 
 require "test_helper"
 require_relative "fixtures/yjs_fixtures"
-require "yrb_lite/sync"
+require "yrb_lite/action_cable"
 
 class SyncTest < Minitest::Test
   class SyncHelper
-    include YrbLite::Sync
+    include YrbLite::ActionCable::Sync
   end
 
   def setup
     @helper = SyncHelper.new
-    YrbLite::Sync.reset!
+    YrbLite::ActionCable::Sync.reset!
   end
 
   def test_awareness_for_returns_same_instance_for_same_key
-    a1 = YrbLite::Sync.awareness_for("test-room")
-    a2 = YrbLite::Sync.awareness_for("test-room")
+    a1 = YrbLite::ActionCable::Sync.awareness_for("test-room")
+    a2 = YrbLite::ActionCable::Sync.awareness_for("test-room")
 
     assert_same a1, a2
   end
 
   def test_awareness_for_different_keys
-    a1 = YrbLite::Sync.awareness_for("room-1")
-    a2 = YrbLite::Sync.awareness_for("room-2")
+    a1 = YrbLite::ActionCable::Sync.awareness_for("room-1")
+    a2 = YrbLite::ActionCable::Sync.awareness_for("room-2")
 
     refute_same a1, a2
   end
@@ -42,8 +42,8 @@ class SyncTest < Minitest::Test
       state
     end
 
-    awareness = YrbLite::Sync.awareness_for("loaded-room", loader)
-    YrbLite::Sync.awareness_for("loaded-room", loader)
+    awareness = YrbLite::ActionCable::Sync.awareness_for("loaded-room", loader)
+    YrbLite::ActionCable::Sync.awareness_for("loaded-room", loader)
 
     assert_equal 1, calls, "on_load should run once per key"
     target.apply_update(awareness.encode_state_as_update)
@@ -53,7 +53,7 @@ class SyncTest < Minitest::Test
 
   def test_awareness_for_is_thread_safe_on_creation
     instances = 16.times.map do
-      Thread.new { YrbLite::Sync.awareness_for("contended-room") }
+      Thread.new { YrbLite::ActionCable::Sync.awareness_for("contended-room") }
     end.map(&:value)
 
     assert_equal 1, instances.uniq(&:object_id).length,
@@ -61,20 +61,20 @@ class SyncTest < Minitest::Test
   end
 
   def test_reset_clears_registry
-    YrbLite::Sync.awareness_for("room-1")
+    YrbLite::ActionCable::Sync.awareness_for("room-1")
 
-    refute_empty YrbLite::Sync.registry
+    refute_empty YrbLite::ActionCable::Sync.registry
 
-    YrbLite::Sync.reset!
+    YrbLite::ActionCable::Sync.reset!
 
-    assert_empty YrbLite::Sync.registry
+    assert_empty YrbLite::ActionCable::Sync.registry
   end
 
   # -- Store-backed (AnyCable-native) backend ------------------------------
 
   def store_backed_helper(loader:, recorder:, transmits:, broadcasts:)
     klass = Class.new do
-      include YrbLite::Sync
+      include YrbLite::ActionCable::Sync
 
       sync_backend :store
       attr_accessor :_t, :_b
@@ -91,7 +91,7 @@ class SyncTest < Minitest::Test
   end
 
   def test_sync_backend_defaults_to_memory_and_is_settable
-    klass = Class.new { include YrbLite::Sync }
+    klass = Class.new { include YrbLite::ActionCable::Sync }
 
     assert_equal :memory, klass.sync_backend
     klass.sync_backend :store
@@ -156,8 +156,8 @@ class SyncTest < Minitest::Test
   # -- Multi-process replica sync ------------------------------------------
 
   def test_process_id_is_stable
-    assert_kind_of String, YrbLite::Sync.process_id
-    assert_equal YrbLite::Sync.process_id, YrbLite::Sync.process_id
+    assert_kind_of String, YrbLite::ActionCable::Sync.process_id
+    assert_equal YrbLite::ActionCable::Sync.process_id, YrbLite::ActionCable::Sync.process_id
   end
 
   def test_remote_change_is_applied_to_replica_without_recording
@@ -172,7 +172,7 @@ class SyncTest < Minitest::Test
     helper.send(:sync_on_broadcast,
                 { "m" => Base64.strict_encode64(msg), "origin" => "other", "pid" => "process-b" })
 
-    refute_equal empty_sv, YrbLite::Sync.registry[key].encode_state_vector,
+    refute_equal empty_sv, YrbLite::ActionCable::Sync.registry[key].encode_state_vector,
                  "a remote process's change updates this process's replica"
     assert_empty recorded, "a remote change is not re-recorded here"
   end
@@ -184,51 +184,51 @@ class SyncTest < Minitest::Test
     msg = YrbLite::Awareness.new.encode_update(YjsFixtures::TwoDocsMerged::DOC1_UPDATE)
 
     helper.send(:sync_on_broadcast,
-                { "m" => Base64.strict_encode64(msg), "origin" => "x", "pid" => YrbLite::Sync.process_id })
+                { "m" => Base64.strict_encode64(msg), "origin" => "x", "pid" => YrbLite::ActionCable::Sync.process_id })
 
-    assert_equal sv_before, YrbLite::Sync.registry[key].encode_state_vector,
+    assert_equal sv_before, YrbLite::ActionCable::Sync.registry[key].encode_state_vector,
                  "a broadcast from this same process is not applied a second time"
   end
 
   # -- Idle document eviction ----------------------------------------------
 
   def test_release_evicts_when_last_subscriber_leaves
-    YrbLite::Sync.awareness_for("evict-room")
-    YrbLite::Sync.subscribe("evict-room")
-    YrbLite::Sync.subscribe("evict-room") # two subscribers
+    YrbLite::ActionCable::Sync.awareness_for("evict-room")
+    YrbLite::ActionCable::Sync.subscribe("evict-room")
+    YrbLite::ActionCable::Sync.subscribe("evict-room") # two subscribers
 
     saved = []
 
-    refute YrbLite::Sync.release("evict-room", evictable: true) { |_a| saved << :save },
+    refute YrbLite::ActionCable::Sync.release("evict-room", evictable: true) { |_a| saved << :save },
            "one subscriber remains, so not evicted"
-    assert YrbLite::Sync.registry.key?("evict-room")
+    assert YrbLite::ActionCable::Sync.registry.key?("evict-room")
     assert_empty saved
 
-    assert YrbLite::Sync.release("evict-room", evictable: true) { |_a| saved << :save },
+    assert YrbLite::ActionCable::Sync.release("evict-room", evictable: true) { |_a| saved << :save },
            "last subscriber left, so evicted"
-    refute YrbLite::Sync.registry.key?("evict-room")
+    refute YrbLite::ActionCable::Sync.registry.key?("evict-room")
     assert_equal [:save], saved, "persisted exactly once before eviction"
   end
 
   def test_release_keeps_document_when_not_evictable
-    YrbLite::Sync.awareness_for("keep-room")
-    YrbLite::Sync.subscribe("keep-room")
+    YrbLite::ActionCable::Sync.awareness_for("keep-room")
+    YrbLite::ActionCable::Sync.subscribe("keep-room")
 
-    refute YrbLite::Sync.release("keep-room", evictable: false)
-    assert YrbLite::Sync.registry.key?("keep-room"),
+    refute YrbLite::ActionCable::Sync.release("keep-room", evictable: false)
+    assert YrbLite::ActionCable::Sync.registry.key?("keep-room"),
            "with no on_load, unloading would lose data, so keep it warm"
   end
 
   def test_eviction_aborts_if_a_subscriber_returns_during_persist
-    YrbLite::Sync.awareness_for("race-room")
-    YrbLite::Sync.subscribe("race-room")
+    YrbLite::ActionCable::Sync.awareness_for("race-room")
+    YrbLite::ActionCable::Sync.subscribe("race-room")
 
-    evicted = YrbLite::Sync.release("race-room", evictable: true) do |_a|
-      YrbLite::Sync.subscribe("race-room") # someone reconnects mid-persist
+    evicted = YrbLite::ActionCable::Sync.release("race-room", evictable: true) do |_a|
+      YrbLite::ActionCable::Sync.subscribe("race-room") # someone reconnects mid-persist
     end
 
     refute evicted, "eviction must abort if a subscriber returned during persist"
-    assert YrbLite::Sync.registry.key?("race-room")
+    assert YrbLite::ActionCable::Sync.registry.key?("race-room")
   end
 
   # -- Authoritative (record-before-distribute) path -----------------------
@@ -245,7 +245,7 @@ class SyncTest < Minitest::Test
   # call so on_change never leaks between tests.
   def authoritative_helper(key, broadcasts:, &recorder)
     klass = Class.new do
-      include YrbLite::Sync
+      include YrbLite::ActionCable::Sync
 
       attr_accessor :captured_broadcasts
 
@@ -266,7 +266,7 @@ class SyncTest < Minitest::Test
     broadcasts = []
     events = []
     recorder = lambda do |k, update|
-      awareness = YrbLite::Sync.registry[k]
+      awareness = YrbLite::ActionCable::Sync.registry[k]
       events << {
         key: k,
         update: update.dup,
@@ -290,7 +290,7 @@ class SyncTest < Minitest::Test
     assert_equal 0, event[:broadcasts_at_record],
                  "nothing may be distributed before the change is recorded"
 
-    refute_equal empty_sv, YrbLite::Sync.registry[key].encode_state_vector,
+    refute_equal empty_sv, YrbLite::ActionCable::Sync.registry[key].encode_state_vector,
                  "change is applied after recording"
     assert_equal 1, broadcasts.length, "change is distributed after recording"
   end
@@ -302,7 +302,7 @@ class SyncTest < Minitest::Test
     key = "ctx-room"
     recorded_author = nil
     klass = Class.new do
-      include YrbLite::Sync
+      include YrbLite::ActionCable::Sync
 
       attr_accessor :captured_broadcasts
 
@@ -332,7 +332,7 @@ class SyncTest < Minitest::Test
     recorder = Object.new
     recorder.define_singleton_method(:call) { |k, update| seen << [k, update.bytesize] }
     klass = Class.new do
-      include YrbLite::Sync
+      include YrbLite::ActionCable::Sync
 
       attr_accessor :captured_broadcasts
 
@@ -365,7 +365,7 @@ class SyncTest < Minitest::Test
       helper.sync_receive(update_message(YjsFixtures::TwoDocsMerged::DOC1_UPDATE))
     end
 
-    assert_equal empty_sv, YrbLite::Sync.registry[key].encode_state_vector,
+    assert_equal empty_sv, YrbLite::ActionCable::Sync.registry[key].encode_state_vector,
                  "a change that could not be recorded must not be applied"
     assert_empty broadcasts,
                  "a change that could not be recorded must not be distributed"
@@ -416,7 +416,7 @@ class SyncTest < Minitest::Test
     client = YrbLite::Doc.new
     [YjsFixtures::CausalChain::U1, YjsFixtures::CausalChain::U2,
      YjsFixtures::CausalChain::U3].each { |u| client.apply_update(u) }
-    server = YrbLite::Sync.registry[key]
+    server = YrbLite::ActionCable::Sync.registry[key]
     resync = client.encode_state_as_update(server.encode_state_vector)
     helper.sync_receive(update_message(resync))
 
@@ -483,7 +483,7 @@ class SyncTest < Minitest::Test
 
     assert_empty recorded, "a no-op change must not be recorded"
     assert_empty broadcasts, "a no-op change must not be distributed"
-    assert_equal empty_sv, YrbLite::Sync.registry[key].encode_state_vector
+    assert_equal empty_sv, YrbLite::ActionCable::Sync.registry[key].encode_state_vector
   end
 
   def test_unrecorded_change_is_invisible_to_concurrent_readers
@@ -507,7 +507,7 @@ class SyncTest < Minitest::Test
     end
 
     entered.pop # recorder is now mid-write; the change is not yet recorded
-    server = YrbLite::Sync.registry[key]
+    server = YrbLite::ActionCable::Sync.registry[key]
 
     assert_equal empty_sv, server.encode_state_vector,
                  "a change still being recorded must be invisible to a resync/read"
@@ -534,13 +534,13 @@ class SyncTest < Minitest::Test
     assert_raises(RuntimeError) do
       helper.sync_receive(update_message(YjsFixtures::TwoDocsMerged::DOC1_UPDATE))
     end
-    assert_equal empty_sv, YrbLite::Sync.registry[key].encode_state_vector,
+    assert_equal empty_sv, YrbLite::ActionCable::Sync.registry[key].encode_state_vector,
                  "failed change is not applied"
 
     failing = false
     helper.sync_receive(update_message(YjsFixtures::TwoDocsMerged::DOC1_UPDATE))
 
-    refute_equal empty_sv, YrbLite::Sync.registry[key].encode_state_vector,
+    refute_equal empty_sv, YrbLite::ActionCable::Sync.registry[key].encode_state_vector,
                  "the re-offered change records and applies after recovery"
   end
 
@@ -583,7 +583,7 @@ class SyncTest < Minitest::Test
     # The authoritative document is exactly the in-order replay of the log.
     replay = YrbLite::Doc.new
     log.each { |update| replay.apply_update(update) }
-    server = YrbLite::Sync.registry[key]
+    server = YrbLite::ActionCable::Sync.registry[key]
 
     assert_equal server.encode_state_vector, replay.encode_state_vector
     assert_equal server.encode_state_as_update, replay.encode_state_as_update,
@@ -596,7 +596,7 @@ class SyncTest < Minitest::Test
   # distributions. Used to observe acks without touching ActionCable.
   def fast_helper(key, transmits:, broadcasts:)
     klass = Class.new do
-      include YrbLite::Sync
+      include YrbLite::ActionCable::Sync
 
       attr_accessor :_t, :_b
 

--- a/yrb-lite-actioncable.gemspec
+++ b/yrb-lite-actioncable.gemspec
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative "lib/yrb_lite/action_cable/version"
+
+Gem::Specification.new do |spec|
+  spec.name = "yrb-lite-actioncable"
+  spec.version = YrbLite::ActionCable::VERSION
+  spec.authors = ["JP Camara"]
+  spec.email = ["johnpcamara@gmail.com"]
+
+  spec.summary = "ActionCable integration for yrb-lite: the y-websocket sync protocol and awareness over ActionCable/AnyCable"
+  spec.description = "yrb-lite-actioncable adds a Rails ActionCable channel concern (YrbLite::ActionCable::Sync) on " \
+                     "top of the yrb-lite y-crdt bindings: the full y-websocket sync protocol, awareness/presence, " \
+                     "record-before-distribute auditing, and memory/store backends (AnyCable-ready), so a Rails app " \
+                     "can be the collaboration server for Y.js editors with no Node sidecar."
+  spec.homepage = "https://github.com/jpcamara/yrb-lite"
+  spec.license = "MIT"
+  spec.required_ruby_version = ">= 3.4.0"
+
+  spec.files = Dir[
+    "lib/yrb-lite-actioncable.rb",
+    "lib/yrb_lite/action_cable.rb",
+    "lib/yrb_lite/action_cable/**/*.rb",
+    "LICENSE",
+    "README.md",
+    "CHANGELOG-actioncable.md"
+  ]
+  spec.require_paths = ["lib"]
+
+  spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG-actioncable.md"
+  spec.metadata["bug_tracker_uri"] = "#{spec.homepage}/issues"
+  spec.metadata["rubygems_mfa_required"] = "true"
+
+  spec.add_dependency "base64", "~> 0.2"
+  spec.add_dependency "yrb-lite", ">= 0.1.0.beta5"
+
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+end

--- a/yrb-lite.gemspec
+++ b/yrb-lite.gemspec
@@ -8,15 +8,17 @@ Gem::Specification.new do |spec|
   spec.authors = ["JP Camara"]
   spec.email = ["johnpcamara@gmail.com"]
 
-  spec.summary = "Thread-safe Ruby bindings for y-crdt (Y.js) with the y-websocket sync protocol for ActionCable"
-  spec.description = "yrb-lite is a thread-safe Ruby binding over the Rust y-crdt (yrs) library plus an " \
-                     "ActionCable concern implementing the full y-websocket sync protocol and awareness. It " \
-                     "lets a Rails app be the collaboration server for Y.js editors (Tiptap, ProseMirror, " \
-                     "BlockNote) with no Node sidecar."
+  spec.summary = "Thread-safe Ruby bindings for y-crdt (Y.js): documents, awareness, and the y-websocket sync protocol"
+  spec.description = "yrb-lite is a thread-safe Ruby binding over the Rust y-crdt (yrs) library: CRDT documents, " \
+                     "awareness/presence, and the y-websocket sync protocol primitives, with the GVL released " \
+                     "during native work so documents sync in parallel. The ActionCable/Rails integration lives " \
+                     "in the companion yrb-lite-actioncable gem."
   spec.homepage = "https://github.com/jpcamara/yrb-lite"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.4.0"
 
+  # The ActionCable layer (lib/yrb_lite/action_cable*) ships in the separate
+  # yrb-lite-actioncable gem, so it's excluded from the core gem here.
   spec.files = Dir[
     "lib/**/*.rb",
     "ext/**/*.{rb,rs,toml}",
@@ -24,7 +26,7 @@ Gem::Specification.new do |spec|
     "LICENSE",
     "README.md",
     "CHANGELOG.md"
-  ]
+  ] - Dir["lib/yrb-lite-actioncable.rb", "lib/yrb_lite/action_cable.rb", "lib/yrb_lite/action_cable/**/*"]
 
   spec.require_paths = ["lib"]
   spec.extensions = ["ext/yrb_lite/extconf.rb"]
@@ -34,8 +36,6 @@ Gem::Specification.new do |spec|
   spec.metadata["bug_tracker_uri"] = "#{spec.homepage}/issues"
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  # base64 stopped being a default gem in Ruby 3.4, so depend on it explicitly.
-  spec.add_dependency "base64", "~> 0.2"
   spec.add_dependency "rb_sys", "~> 0.9"
 
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
Splits the gem in two, mirroring the **y-rb / yrb-actioncable** split: most users want the CRDT bindings without buying into Rails/ActionCable.

## Two gems

| `yrb-lite` (core, → 0.1.0.beta5) | `yrb-lite-actioncable` (new, 0.1.0.beta1) |
|---|---|
| Native Rust ext: `YrbLite::Doc`, `YrbLite::Awareness`, y-websocket sync-protocol primitives | `YrbLite::ActionCable::Sync` channel concern |
| No Rails/ActionCable coupling; drops the `base64` runtime dep | registry/backends (`:memory`/`:store`), presence reaping, multi-process broadcast, audit hooks — behavior unchanged |
| ships the ext | depends on `yrb-lite (>= 0.1.0.beta5)` |

The dependency arrow already pointed the right way (the channel layer used the native API; core never referenced the channel), so this is mostly moving files: `lib/yrb_lite/sync.rb` → `lib/yrb_lite/action_cable/sync.rb`, re-namespaced `YrbLite::Sync` → `YrbLite::ActionCable::Sync`. Lexical `Sync.*` refs and fully-qualified `YrbLite::Doc`/`Awareness` refs carry over unchanged.

Monorepo with two gemspecs: `bundler/gem_tasks` scoped to the core gem; `rake actioncable:build` builds the pure-Ruby cable gem.

## Breaking change + migration

`YrbLite::Sync` is removed from core. Consumers add `gem "yrb-lite-actioncable"` and change `include YrbLite::Sync` → `include YrbLite::ActionCable::Sync`. The concern's API is otherwise identical. Doc/Awareness-only users are unaffected.

## Verification

- 93 ruby tests, 6 cargo tests, clippy + rubocop clean
- both gems build with a clean file partition (core ships the ext; cable ships only the channel code; cable deps = `yrb-lite` + `base64`)
- demo updated (`YrbLite::ActionCable::Sync` + Gemfile) and e2e green through real ActionCable (provider_check, audit, audit_scenarios, reliable, chaos)

Release (core beta5 + cable beta1 together) is a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)