### PR TITLE
Add SyncEngine (sync steps + encode/decode) to yrb-lite-reliable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-      - run: node --test
+      - run: npm ci
+      - run: npm test
 
   demo:
     name: Demo e2e (Ruby ${{ matrix.ruby }})

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ mkmf.log
 *.gem
 /pkg/
 
+# Node
+node_modules/
+
 # IDE
 .idea/
 *.swp

--- a/packages/yrb-lite-reliable/README.md
+++ b/packages/yrb-lite-reliable/README.md
@@ -1,22 +1,21 @@
 # yrb-lite-reliable
 
-The transport-agnostic **reliable-delivery core** for the
-[`yrb-lite`](https://github.com/jpcamara/yrb-lite) y-websocket protocol — the
-nuances a provider would otherwise re-implement, factored out so you can compose
-them inside *your own* Yjs provider.
+The **client core** for the [`yrb-lite`](https://github.com/jpcamara/yrb-lite)
+y-websocket protocol — everything a Yjs provider needs *except the transport*.
+Bring your own socket (ActionCable, AnyCable, raw WebSocket); this owns the
+protocol.
 
-It owns:
+Two layers, use whichever you need:
 
-- an **ack-tracked queue** of unacknowledged local updates,
-- **"sync since last ack"** — the unacked tail is sent as one *merged*,
-  causally-complete delta, so the server never sees an internal gap,
-- **cumulative acks** — `{ ack: id }` confirms every update with `seq <= id`,
-- **retransmit** on a timer with a **"server doesn't support acks" fallback**,
-- **reconnect replay** of the unacked tail.
-
-It does **not** touch any transport, Yjs document binding, awareness/presence, or
-wire encoding. You inject `send` and `merge` and drive it from your provider's
-lifecycle.
+- **`SyncEngine`** — batteries-included. Binds to a `Y.Doc` (+ optional
+  `Awareness`) and owns the y-protocols **message encode/decode**, the
+  **sync-step handshake** (SyncStep1 / SyncStep2 / Update), **awareness**, and
+  reliable delivery. Speaks raw `Uint8Array` frames; you only wire the socket.
+- **`ReliableSync`** — the zero-dependency reliable-delivery state machine on its
+  own: ack-tracked queue, **sync-since-last-ack** (the unacked tail merged into
+  one causally-complete delta), cumulative acks, retransmit + "server doesn't
+  support acks" fallback, and reconnect replay. Compose it yourself if you
+  already have your own framing.
 
 ## Install
 
@@ -24,81 +23,67 @@ lifecycle.
 npm install yrb-lite-reliable
 ```
 
-No dependencies. You supply `merge` (typically `Y.mergeUpdates` from `yjs`, which
-your provider already has).
+`SyncEngine` needs `yjs` and `y-protocols` (peers — your provider already has
+them). `ReliableSync` has **no dependencies**; import it on its own via
+`yrb-lite-reliable/reliable` if that's all you want.
 
-## API
+## SyncEngine
 
 ```js
-import { ReliableSync } from "yrb-lite-reliable";
+import { SyncEngine, toBase64, fromBase64 } from "yrb-lite-reliable";
+import * as Y from "yjs";
+import { Awareness } from "y-protocols/awareness";
 
-const rs = new ReliableSync({
-  // Transmit one update. `update` is the raw merged bytes; `id` is the
-  // cumulative sequence (or undefined post-fallback). You frame + send it.
-  send: (update, id) => { /* writeUpdate + base64 + put on your socket */ },
-  // Merge an array of update byte-arrays into one (Y.mergeUpdates).
-  merge: (updates) => Y.mergeUpdates(updates),
-  resendInterval: 1000,        // ms between retransmits (default 1000)
-  maxUnconfirmedResends: 8,    // resends with no ack before falling back
-  onFallback: () => {},        // optional: called once if that fallback trips
+const doc = new Y.Doc();
+const awareness = new Awareness(doc);
+
+const engine = new SyncEngine(doc, {
+  awareness,
+  // transmit one raw frame; `id` is set for reliable doc updates -> tag your envelope
+  send: (frame, id) => {
+    const payload = { update: toBase64(frame) };
+    if (id !== undefined) payload.id = id;
+    subscription.send(payload);
+  },
 });
 
-rs.enqueue(update);  // a local document update (never a server echo)
-rs.onAck(id);        // an { ack: id } frame arrived
-rs.onConnect();      // transport (re)connected — replays the tail, starts retransmits
-rs.onDisconnect();   // transport dropped — keeps the queue, pauses retransmits
-rs.hasPending;       // are there unacknowledged updates?
-rs.destroy();        // stop timers, drop the queue
+// wire your transport's callbacks:
+subscription.connected    = () => engine.onConnect();      // handshake + replay
+subscription.disconnected = () => engine.onDisconnect();   // pause + clear presence
+subscription.received = (msg) => {
+  if (msg.ack !== undefined) return engine.ack(msg.ack);   // reliable ack envelope
+  const reply = engine.receive(fromBase64(msg.update || msg.m)); // decode + apply
+  if (reply) subscription.send({ update: toBase64(reply) });     // e.g. answer a SyncStep1
+};
+// engine.synced -> caught up; engine.hasPending -> unacked edits in flight
+// engine.destroy() -> detach listeners + stop retransmits
 ```
 
-## Composing it in a provider
+Local document edits and awareness changes are picked up automatically from the
+doc's / awareness's `update` events — you never call anything for outbound edits.
+
+## ReliableSync (standalone)
 
 ```js
-import { ReliableSync } from "yrb-lite-reliable";
+import { ReliableSync } from "yrb-lite-reliable/reliable"; // zero-dep
 import * as Y from "yjs";
-import * as encoding from "lib0/encoding";
-import { writeUpdate } from "y-protocols/sync";
 
-const MessageType = { Sync: 0 };
-const toBase64 = (b) => btoa(String.fromCharCode(...b));
+const rs = new ReliableSync({
+  send: (update, id) => { /* frame + transmit */ },
+  merge: Y.mergeUpdates,
+});
 
-class MyProvider {
-  constructor(doc, subscription) {
-    this.doc = doc;
-    this.subscription = subscription;
-
-    this.reliable = new ReliableSync({
-      merge: Y.mergeUpdates,
-      send: (update, id) => {
-        const enc = encoding.createEncoder();
-        encoding.writeVarUint(enc, MessageType.Sync);
-        writeUpdate(enc, update);                    // frame it (provider's job)
-        const payload = { update: toBase64(encoding.toUint8Array(enc)) };
-        if (id !== undefined) payload.id = id;        // tag for the ack
-        this.subscription.send(payload);              // transport (provider's job)
-      },
-    });
-
-    // local edits -> queue (ignore updates we applied FROM the server)
-    doc.on("update", (update, origin) => {
-      if (origin !== this) this.reliable.enqueue(update);
-    });
-  }
-
-  // wire these to your transport's callbacks:
-  received(message) {
-    if (message.ack !== undefined) return this.reliable.onAck(message.ack);
-    /* ...decode + apply sync/awareness as usual... */
-  }
-  connected()    { /* send SyncStep1, then: */ this.reliable.onConnect(); }
-  disconnected() { this.reliable.onDisconnect(); }
-  destroy()      { this.reliable.destroy(); }
-}
+rs.enqueue(update);  // a local document update
+rs.onAck(id);        // an { ack: id } arrived
+rs.onConnect();      // (re)connected — replay the tail, resume retransmits
+rs.onDisconnect();   // dropped — keep the queue, pause
 ```
 
-The server side (ack generation, gap detection) is the
-[`yrb-lite-actioncable`](https://github.com/jpcamara/yrb-lite) gem's
-`YrbLite::ActionCable::Sync`. This package is the client counterpart.
+## How it fits
+
+The server counterpart — ack *generation*, gap detection, record-before-distribute
+— is the `yrb-lite-actioncable` gem's `YrbLite::ActionCable::Sync`. This package
+is the client half of the same protocol.
 
 ## License
 

--- a/packages/yrb-lite-reliable/package-lock.json
+++ b/packages/yrb-lite-reliable/package-lock.json
@@ -1,0 +1,101 @@
+{
+  "name": "yrb-lite-reliable",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "yrb-lite-reliable",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "y-protocols": "^1.0.5",
+        "yjs": "^13.6.0"
+      },
+      "peerDependencies": {
+        "y-protocols": "^1.0.5",
+        "yjs": "^13.6.0"
+      },
+      "peerDependenciesMeta": {
+        "y-protocols": {
+          "optional": true
+        },
+        "yjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/y-protocols": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
+      "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.85"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.31",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.31.tgz",
+      "integrity": "sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    }
+  }
+}

--- a/packages/yrb-lite-reliable/package.json
+++ b/packages/yrb-lite-reliable/package.json
@@ -1,12 +1,14 @@
 {
   "name": "yrb-lite-reliable",
   "version": "0.1.0",
-  "description": "Transport-agnostic reliable-delivery core for the yrb-lite y-websocket protocol: ack-tracked queue, sync-since-last-ack merged updates, retransmit + reconnect replay. Compose it inside your own Yjs provider.",
+  "description": "Client core for the yrb-lite y-websocket protocol: sync steps, message encode/decode, awareness, and reliable delivery (ack-tracked queue, sync-since-last-ack, retransmit + reconnect replay). Bring your own transport.",
   "type": "module",
   "main": "src/index.js",
   "module": "src/index.js",
   "exports": {
-    ".": "./src/index.js"
+    ".": "./src/index.js",
+    "./reliable": "./src/reliable_sync.js",
+    "./base64": "./src/base64.js"
   },
   "files": [
     "src",
@@ -36,5 +38,21 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependencies": {
+    "yjs": "^13.6.0",
+    "y-protocols": "^1.0.5"
+  },
+  "peerDependenciesMeta": {
+    "yjs": {
+      "optional": true
+    },
+    "y-protocols": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "yjs": "^13.6.0",
+    "y-protocols": "^1.0.5"
   }
 }

--- a/packages/yrb-lite-reliable/src/base64.js
+++ b/packages/yrb-lite-reliable/src/base64.js
@@ -1,0 +1,9 @@
+// Convenience codecs for transports that carry binary frames as base64 strings
+// (e.g. ActionCable's JSON envelope). Optional -- a binary WebSocket transport
+// sends the raw frames directly and never needs these.
+
+/** @param {Uint8Array} bytes */
+export const toBase64 = (bytes) => btoa(Array.from(bytes, (b) => String.fromCharCode(b)).join(""));
+
+/** @param {string} str */
+export const fromBase64 = (str) => Uint8Array.from(atob(str), (c) => c.charCodeAt(0));

--- a/packages/yrb-lite-reliable/src/index.js
+++ b/packages/yrb-lite-reliable/src/index.js
@@ -1,1 +1,9 @@
+// Zero-dependency reliable-delivery core. Safe to import on its own.
 export { ReliableSync } from "./reliable_sync.js";
+
+// Batteries-included protocol client (sync steps + encode/decode + awareness).
+// Requires `yjs` and `y-protocols` as peers.
+export { SyncEngine, MessageType } from "./sync_engine.js";
+
+// Optional base64 helpers for transports that carry frames as strings.
+export { toBase64, fromBase64 } from "./base64.js";

--- a/packages/yrb-lite-reliable/src/sync_engine.js
+++ b/packages/yrb-lite-reliable/src/sync_engine.js
@@ -1,0 +1,187 @@
+// A batteries-included client core for the yrb-lite y-websocket protocol.
+//
+// SyncEngine composes ReliableSync and additionally owns the parts a provider
+// would otherwise re-implement: the y-protocols message framing (encode/decode),
+// the sync-step handshake (SyncStep1 / SyncStep2 / Update), and awareness
+// encode/apply. It binds to a Y.Doc (and optional Awareness) and speaks in raw
+// Uint8Array frames -- you bring only the transport: base64 + the
+// `{ update, id }` / `{ ack }` envelope and the socket.
+//
+// Drive it from your transport:
+//   onConnect()          -> sends the opening handshake, replays the unacked tail
+//   onDisconnect()       -> pauses retransmits, clears remote presence
+//   ack(id)              -> a `{ ack: id }` envelope arrived
+//   const reply = receive(frame)  -> a binary protocol frame arrived; send `reply` if non-null
+// Local document edits and awareness changes are picked up automatically via the
+// doc's / awareness's "update" events.
+import * as Y from "yjs";
+import * as encoding from "lib0/encoding";
+import * as decoding from "lib0/decoding";
+import { readSyncMessage, writeSyncStep1, writeUpdate, messageYjsSyncStep2 } from "y-protocols/sync";
+import { encodeAwarenessUpdate, applyAwarenessUpdate, removeAwarenessStates } from "y-protocols/awareness";
+import { readAuthMessage } from "y-protocols/auth";
+import { ReliableSync } from "./reliable_sync.js";
+
+export const MessageType = { Sync: 0, Awareness: 1, Auth: 2, QueryAwareness: 3 };
+
+export class SyncEngine {
+  /**
+   * @param {Y.Doc} doc
+   * @param {object} opts
+   * @param {(frame: Uint8Array, id: number|undefined) => void} opts.send
+   *   transmit one raw protocol frame; `id` is set only for reliable document
+   *   updates (tag it onto your envelope so the server can ack).
+   * @param {import("y-protocols/awareness").Awareness} [opts.awareness]
+   * @param {boolean} [opts.reliable=true] use ack-tracked reliable delivery
+   * @param {number} [opts.resendInterval] forwarded to ReliableSync
+   * @param {number} [opts.maxUnconfirmedResends] forwarded to ReliableSync
+   * @param {() => void} [opts.onFallback] forwarded to ReliableSync
+   */
+  constructor(
+    doc,
+    {
+      send,
+      awareness = null,
+      reliable = true,
+      resendInterval,
+      maxUnconfirmedResends,
+      onFallback,
+      setInterval: setIntervalFn,
+      clearInterval: clearIntervalFn,
+    } = {}
+  ) {
+    if (!doc) throw new TypeError("SyncEngine requires a Y.Doc");
+    if (typeof send !== "function") throw new TypeError("SyncEngine requires a send(frame, id) function");
+
+    this.doc = doc;
+    this.awareness = awareness;
+    this.reliable = reliable;
+    this._send = send;
+    this._synced = false;
+
+    this._delivery = new ReliableSync({
+      merge: Y.mergeUpdates,
+      send: (update, id) => this._send(this._frameUpdate(update), id),
+      resendInterval,
+      maxUnconfirmedResends,
+      onFallback,
+      setInterval: setIntervalFn,
+      clearInterval: clearIntervalFn,
+    });
+
+    this._onDocUpdate = (update, origin) => {
+      if (origin === this) return; // applied from the server; don't echo it back
+      if (this.reliable && this._delivery.reliable) this._delivery.enqueue(update);
+      else this._send(this._frameUpdate(update), undefined);
+    };
+    this.doc.on("update", this._onDocUpdate);
+
+    if (this.awareness) {
+      this._onAwarenessUpdate = ({ added, updated, removed }) => {
+        const changed = added.concat(updated, removed);
+        this._send(this._frameAwareness(changed), undefined); // presence: fire-and-forget
+      };
+      this.awareness.on("update", this._onAwarenessUpdate);
+    }
+  }
+
+  /** True once we've received the server's SyncStep2 (the document is caught up). */
+  get synced() {
+    return this._synced;
+  }
+
+  /** True while there are unacknowledged local document updates in flight. */
+  get hasPending() {
+    return this._delivery.hasPending;
+  }
+
+  /** Transport connected: send the opening handshake and replay the unacked tail. */
+  onConnect() {
+    this._send(this._frameSyncStep1(), undefined);
+    if (this.awareness && this.awareness.getLocalState() !== null) {
+      this._send(this._frameAwareness([this.doc.clientID]), undefined);
+    }
+    if (this.reliable) this._delivery.onConnect();
+  }
+
+  /** Transport dropped: pause retransmits (queue kept) and clear remote presence. */
+  onDisconnect() {
+    this._synced = false;
+    this._delivery.onDisconnect();
+    if (this.awareness) {
+      const remote = [...this.awareness.getStates().keys()].filter((c) => c !== this.doc.clientID);
+      if (remote.length) removeAwarenessStates(this.awareness, remote, this);
+    }
+  }
+
+  /** A reliable-delivery `{ ack: id }` envelope arrived. */
+  ack(id) {
+    this._delivery.onAck(id);
+  }
+
+  /**
+   * Decode and apply one incoming binary protocol frame (document sync, awareness,
+   * query, or auth). Returns a reply frame to transmit (e.g. SyncStep2 answering a
+   * SyncStep1, or an awareness reply to a query), or null if there's nothing to send.
+   * @param {Uint8Array} frame
+   * @returns {Uint8Array|null}
+   */
+  receive(frame) {
+    const decoder = decoding.createDecoder(frame);
+    const encoder = encoding.createEncoder();
+    const type = decoding.readVarUint(decoder);
+    switch (type) {
+      case MessageType.Sync: {
+        encoding.writeVarUint(encoder, MessageType.Sync);
+        const syncType = readSyncMessage(decoder, encoder, this.doc, this);
+        if (!this._synced && syncType === messageYjsSyncStep2) this._synced = true;
+        break;
+      }
+      case MessageType.Awareness:
+        if (this.awareness) applyAwarenessUpdate(this.awareness, decoding.readVarUint8Array(decoder), this);
+        return null;
+      case MessageType.QueryAwareness:
+        if (!this.awareness) return null;
+        encoding.writeVarUint(encoder, MessageType.Awareness);
+        encoding.writeVarUint8Array(
+          encoder,
+          encodeAwarenessUpdate(this.awareness, [...this.awareness.getStates().keys()])
+        );
+        break;
+      case MessageType.Auth:
+        readAuthMessage(decoder, this.doc, (_doc, reason) => console.warn(`[yrb-lite] auth denied: ${reason}`));
+        return null;
+      default:
+        return null;
+    }
+    return encoding.length(encoder) > 1 ? encoding.toUint8Array(encoder) : null;
+  }
+
+  /** Detach doc/awareness listeners and stop retransmits. */
+  destroy() {
+    this.doc.off("update", this._onDocUpdate);
+    if (this.awareness && this._onAwarenessUpdate) this.awareness.off("update", this._onAwarenessUpdate);
+    this._delivery.destroy();
+  }
+
+  _frameSyncStep1() {
+    const e = encoding.createEncoder();
+    encoding.writeVarUint(e, MessageType.Sync);
+    writeSyncStep1(e, this.doc);
+    return encoding.toUint8Array(e);
+  }
+
+  _frameUpdate(update) {
+    const e = encoding.createEncoder();
+    encoding.writeVarUint(e, MessageType.Sync);
+    writeUpdate(e, update);
+    return encoding.toUint8Array(e);
+  }
+
+  _frameAwareness(clients) {
+    const e = encoding.createEncoder();
+    encoding.writeVarUint(e, MessageType.Awareness);
+    encoding.writeVarUint8Array(e, encodeAwarenessUpdate(this.awareness, clients));
+    return encoding.toUint8Array(e);
+  }
+}

--- a/packages/yrb-lite-reliable/test/sync_engine.test.js
+++ b/packages/yrb-lite-reliable/test/sync_engine.test.js
@@ -1,0 +1,183 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as Y from "yjs";
+import * as encoding from "lib0/encoding";
+import { writeSyncStep1, writeUpdate } from "y-protocols/sync";
+import { Awareness, encodeAwarenessUpdate } from "y-protocols/awareness";
+import { SyncEngine, MessageType } from "../src/sync_engine.js";
+
+const MSG = MessageType;
+
+// Read the leading message type off a frame without consuming it elsewhere.
+const frameType = (frame) => frame[0];
+
+// Fake timers keep the resend loop out of the real event loop so tests don't hang.
+const noTimers = { setInterval: () => 0, clearInterval: () => {} };
+
+function engine(opts = {}) {
+  const doc = new Y.Doc();
+  const sent = []; // [{ frame, id }]
+  const eng = new SyncEngine(doc, { send: (frame, id) => sent.push({ frame, id }), ...noTimers, ...opts });
+  return { doc, eng, sent };
+}
+
+// Build a peer's SyncStep1 / Update frames with y-protocols directly.
+function syncStep1Frame(doc) {
+  const e = encoding.createEncoder();
+  encoding.writeVarUint(e, MSG.Sync);
+  writeSyncStep1(e, doc);
+  return encoding.toUint8Array(e);
+}
+function updateFrame(update) {
+  const e = encoding.createEncoder();
+  encoding.writeVarUint(e, MSG.Sync);
+  writeUpdate(e, update);
+  return encoding.toUint8Array(e);
+}
+
+test("requires a doc and a send function", () => {
+  assert.throws(() => new SyncEngine(null, { send: () => {} }), /Y\.Doc/);
+  assert.throws(() => new SyncEngine(new Y.Doc(), {}), /send/);
+});
+
+test("onConnect emits a SyncStep1 handshake frame", () => {
+  const { eng, sent } = engine();
+  eng.onConnect();
+  assert.equal(sent.length, 1);
+  assert.equal(frameType(sent[0].frame), MSG.Sync, "handshake is a Sync message");
+  assert.equal(sent[0].id, undefined, "handshake carries no reliable id");
+});
+
+test("a local edit is framed as a Sync update and tagged with a reliable id", () => {
+  const { doc, eng, sent } = engine();
+  eng.onConnect();
+  const before = sent.length;
+  doc.getText("t").insert(0, "hi");
+  const frame = sent.at(-1);
+  assert.equal(sent.length, before + 1);
+  assert.equal(frameType(frame.frame), MSG.Sync);
+  assert.equal(typeof frame.id, "number", "reliable update carries an id");
+  assert.equal(eng.hasPending, true);
+});
+
+test("an ack drains the pending queue", () => {
+  const { doc, eng, sent } = engine();
+  eng.onConnect();
+  doc.getText("t").insert(0, "hi");
+  const { id } = sent.at(-1);
+  eng.ack(id);
+  assert.equal(eng.hasPending, false);
+});
+
+test("reliable:false sends fire-and-forget (no id, nothing pending)", () => {
+  const { doc, eng, sent } = engine({ reliable: false });
+  eng.onConnect();
+  doc.getText("t").insert(0, "hi");
+  assert.equal(sent.at(-1).id, undefined);
+  assert.equal(eng.hasPending, false);
+});
+
+test("receive(SyncStep1) replies with a SyncStep2; receive(Update) applies to the doc", () => {
+  const { doc, eng } = engine();
+  // A peer that already has content sends us its SyncStep1...
+  const peer = new Y.Doc();
+  peer.getText("t").insert(0, "world");
+  const reply = eng.receive(syncStep1Frame(peer));
+  assert.ok(reply, "we answer a SyncStep1 with a reply (our SyncStep2)");
+  assert.equal(frameType(reply), MSG.Sync);
+
+  // ...and then its document update, which we apply.
+  const update = Y.encodeStateAsUpdate(peer);
+  eng.receive(updateFrame(update));
+  assert.equal(doc.getText("t").toString(), "world", "the peer's update is applied locally");
+});
+
+test("synced flips true after a SyncStep2 arrives", () => {
+  const { eng } = engine();
+  assert.equal(eng.synced, false);
+  const peer = new Y.Doc();
+  peer.getText("t").insert(0, "x");
+  // SyncStep1 -> reply is our step2; feeding the peer a step1 makes IT produce a
+  // step2 for us. Simulate the server's SyncStep2 by replying to our step1.
+  eng.onConnect(); // sends our SyncStep1 (ignored here)
+  const serverReplyToOurStep1 = eng.receive(syncStep1Frame(peer)); // step1 in, step2 out is to peer
+  // The server's SyncStep2 *to us*: build it from the peer answering our step vector.
+  const e = encoding.createEncoder();
+  encoding.writeVarUint(e, MSG.Sync);
+  // a SyncStep2 is just an update payload under the step2 tag; reuse writeUpdate's
+  // sibling via the peer's full state as the "diff".
+  writeSyncStep2FromPeer(e, peer);
+  eng.receive(encoding.toUint8Array(e));
+  assert.equal(eng.synced, true, "receiving a SyncStep2 marks us synced");
+  assert.ok(serverReplyToOurStep1);
+});
+
+test("two engines converge end-to-end through a relay", () => {
+  // reliable:false so updates flow immediately with no server to ack them.
+  const docA = new Y.Doc();
+  const docB = new Y.Doc();
+  let a, b;
+  const relay = (target) => (frame) => {
+    const reply = target.receive(frame);
+    // reply (e.g. SyncStep2) goes back to the sender's peer as well
+    return reply;
+  };
+  a = new SyncEngine(docA, {
+    reliable: false,
+    send: (frame) => {
+      const reply = b.receive(frame);
+      if (reply) a.receive(reply);
+    },
+  });
+  b = new SyncEngine(docB, {
+    reliable: false,
+    send: (frame) => {
+      const reply = a.receive(frame);
+      if (reply) b.receive(reply);
+    },
+  });
+  void relay;
+
+  a.onConnect();
+  b.onConnect();
+  docA.getText("t").insert(0, "from A ");
+  docB.getText("t").insert(0, "from B ");
+
+  assert.equal(docA.getText("t").toString(), docB.getText("t").toString(), "docs converge byte-for-byte");
+  assert.ok(docA.getText("t").toString().includes("from A"));
+  assert.ok(docA.getText("t").toString().includes("from B"));
+});
+
+test("awareness: a local presence change is framed; an incoming one is applied", () => {
+  const docA = new Y.Doc();
+  const awA = new Awareness(docA);
+  const sentA = [];
+  const engA = new SyncEngine(docA, { awareness: awA, send: (frame, id) => sentA.push({ frame, id }) });
+
+  awA.setLocalStateField("user", "alice");
+  const awarenessFrame = sentA.find((s) => frameType(s.frame) === MSG.Awareness);
+  assert.ok(awarenessFrame, "a presence change is sent as an Awareness frame");
+  assert.equal(awarenessFrame.id, undefined, "presence is fire-and-forget");
+
+  // Apply alice's presence into a second engine's awareness.
+  const docB = new Y.Doc();
+  const awB = new Awareness(docB);
+  const engB = new SyncEngine(docB, { awareness: awB, send: () => {} });
+  const e = encoding.createEncoder();
+  encoding.writeVarUint(e, MSG.Awareness);
+  encoding.writeVarUint8Array(e, encodeAwarenessUpdate(awA, [docA.clientID]));
+  engB.receive(encoding.toUint8Array(e));
+  assert.equal(awB.getStates().get(docA.clientID)?.user, "alice", "remote presence is applied");
+
+  engA.destroy();
+  engB.destroy();
+  awA.destroy(); // y-protocols Awareness starts its own reaper interval
+  awB.destroy();
+});
+
+// A SyncStep2 frame carrying the peer's full state (server -> us "you're caught up").
+function writeSyncStep2FromPeer(encoder, peer) {
+  // 1 == messageYjsSyncStep2; payload is the state-as-update diff.
+  encoding.writeVarUint(encoder, 1);
+  encoding.writeVarUint8Array(encoder, Y.encodeStateAsUpdate(peer));
+}


### PR DESCRIPTION
Follow-up to the `yrb-lite-reliable` package: it now also handles the **sync steps and message encode/decode**, so a provider only brings the socket.

## Two layers

| `SyncEngine` (new, batteries-included) | `ReliableSync` (existing, zero-dep) |
|---|---|
| binds a `Y.Doc` (+ optional `Awareness`) | the reliable-delivery state machine alone |
| y-protocols **framing**, **sync-step handshake** (Step1/Step2/Update), **awareness** encode/apply | ack-tracked queue, sync-since-last-ack, retransmit + fallback, reconnect replay |
| composes `ReliableSync` underneath | importable on its own via `yrb-lite-reliable/reliable` |
| needs `yjs` + `y-protocols` (peers) | **no dependencies** |

`SyncEngine` speaks raw `Uint8Array` frames; **base64 + the `{update,id}`/`{ack}` envelope stay transport-side** (helpers exported for convenience). Local doc/awareness edits are picked up automatically from their `update` events — the host wires only `onConnect`/`onDisconnect`/`receive`/`ack`.

```js
const engine = new SyncEngine(doc, { awareness, send: (frame, id) => /* envelope + socket */ });
subscription.received = (m) => m.ack != null ? engine.ack(m.ack)
  : (r => r && subscription.send({ update: toBase64(r) }))(engine.receive(fromBase64(m.update)));
```

## Verification

- **18 `node:test` cases** total: the 9 `ReliableSync` cases plus 9 for `SyncEngine` — handshake framing, reliable-id tagging + ack drain, `reliable:false` fire-and-forget, `receive(SyncStep1)` → SyncStep2 reply, `receive(Update)` applies, `synced` flip, **two-engine end-to-end convergence through a relay**, and awareness encode/apply (all using real `yjs`/`y-protocols`).
- **CI**: the `reliable` job now `npm ci` + `npm test` on Node 20 + 22 (lockfile committed). `node_modules` gitignored.
- Peers declared optional so the zero-dep `ReliableSync` path stays warning-free.
- No proprietary identifiers; `CODE_REVIEW_FINDINGS.md` unstaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)