### PR TITLE
Ship ActionCableProvider + awareness whisper support (0.1.2)

### DIFF
--- a/packages/yrb-lite-reliable/README.md
+++ b/packages/yrb-lite-reliable/README.md
@@ -5,12 +5,17 @@ y-websocket protocol — everything a Yjs provider needs *except the transport*.
 Bring your own socket (ActionCable, AnyCable, raw WebSocket); this owns the
 protocol.
 
-Two layers, use whichever you need:
+Three layers, use whichever you need:
 
-- **`SyncEngine`** — batteries-included. Binds to a `Y.Doc` (+ optional
+- **`ActionCableProvider`** — a ready-made Yjs provider for ActionCable /
+  AnyCable. Pass a `Y.Doc`, a cable consumer, and a channel; it wires the
+  subscription and you're collaborating. Awareness/presence is **whispered** over
+  AnyCable (client-to-client, no server round-trip) and falls back to a normal
+  send on plain ActionCable.
+- **`SyncEngine`** — the transport-agnostic core. Binds to a `Y.Doc` (+ optional
   `Awareness`) and owns the y-protocols **message encode/decode**, the
   **sync-step handshake** (SyncStep1 / SyncStep2 / Update), **awareness**, and
-  reliable delivery. Speaks raw `Uint8Array` frames; you only wire the socket.
+  reliable delivery. Speaks raw `Uint8Array` frames; you wire any socket.
 - **`ReliableSync`** — the zero-dependency reliable-delivery state machine on its
   own: ack-tracked queue, **sync-since-last-ack** (the unacked tail merged into
   one causally-complete delta), cumulative acks, retransmit + "server doesn't
@@ -23,13 +28,38 @@ Two layers, use whichever you need:
 npm install yrb-lite-reliable
 ```
 
-`SyncEngine` needs `yjs` and `y-protocols` (peers — your provider already has
-them). `ReliableSync` has **no dependencies**; import it on its own via
-`yrb-lite-reliable/reliable` if that's all you want.
+`ActionCableProvider` and `SyncEngine` need `yjs` and `y-protocols` (peers — your
+app already has them), plus an ActionCable/AnyCable consumer. `ReliableSync` has
+**no dependencies**; import it on its own via `yrb-lite-reliable/reliable` if
+that's all you want.
 
 Written in **TypeScript** and ships bundled type declarations, so TS projects get
 full types (typed options, methods, and errors) with no `@types` package — and
 plain-JS projects use the same compiled ESM with nothing extra to install.
+
+## ActionCableProvider (the easy path)
+
+```js
+import { ActionCableProvider } from "yrb-lite-reliable";
+import * as Y from "yjs";
+import { createConsumer } from "@anycable/web"; // or @rails/actioncable
+
+const doc = new Y.Doc();
+const consumer = createConsumer();
+const provider = new ActionCableProvider(doc, consumer, "DocumentChannel", { id: docId });
+
+provider.connect(); // does not auto-connect — wire your editor binding first
+// provider.awareness  -> the Awareness instance (a fresh one unless you pass opts.awareness)
+// provider.synced     -> caught up with the server
+// provider.hasPending -> unacked local edits in flight
+// provider.destroy()  -> tear down
+```
+
+On the server, include `YrbLite::ActionCable::Sync` in a channel named
+`DocumentChannel` (the [`yrb-lite-actioncable`](https://rubygems.org/gems/yrb-lite-actioncable)
+gem). Awareness/presence is whispered over AnyCable when available and sent
+normally on plain ActionCable. Need different transport or framing? Drop down to
+`SyncEngine` and supply your own `send`.
 
 ## SyncEngine
 

--- a/packages/yrb-lite-reliable/package-lock.json
+++ b/packages/yrb-lite-reliable/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yrb-lite-reliable",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yrb-lite-reliable",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.6.0",

--- a/packages/yrb-lite-reliable/package.json
+++ b/packages/yrb-lite-reliable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yrb-lite-reliable",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Client core for the yrb-lite y-websocket protocol: sync steps, message encode/decode, awareness, and reliable delivery (ack-tracked queue, sync-since-last-ack, retransmit + reconnect replay). Written in TypeScript with bundled types; usable from plain JS. Bring your own transport.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/yrb-lite-reliable/src/actioncable_provider.ts
+++ b/packages/yrb-lite-reliable/src/actioncable_provider.ts
@@ -1,0 +1,144 @@
+// A ready-made Yjs provider for the yrb-lite y-websocket protocol over
+// ActionCable / AnyCable. It owns the cable subscription and translates between
+// the cable's JSON envelope (`{ update, id }` / `{ ack }`, base64) and raw
+// protocol frames; everything else (sync steps, encode/decode, awareness,
+// reliable delivery) lives in SyncEngine. So this is just the transport glue.
+//
+// Awareness/presence frames are sent via AnyCable's `whisper` when the
+// subscription supports it (client-to-client, no server round-trip); on plain
+// ActionCable (no `whisper`) they fall back to a normal `send` and the server
+// relays them. Document updates always go through `send` (they must be
+// recorded/acked).
+//
+// The constructor does NOT auto-connect: wire your editor binding first, then
+// call `connect()`. Same `(doc, consumer, channelName, channelParams, opts)`
+// shape as a typical y-rb/actioncable provider.
+import { SyncEngine, MessageType, type SyncEngineOptions, type SendOptions } from "./sync_engine.js";
+import { toBase64, fromBase64 } from "./base64.js";
+import { Awareness } from "y-protocols/awareness";
+import type { Doc } from "yjs";
+
+/** The minimal slice of an ActionCable/AnyCable subscription this provider uses. */
+export interface CableSubscription {
+  send(data: unknown): unknown;
+  /** AnyCable client-to-client broadcast; absent on plain ActionCable. */
+  whisper?(data: unknown): unknown;
+  unsubscribe?(): void;
+}
+
+/** The minimal slice of an ActionCable/AnyCable consumer this provider uses. */
+export interface CableConsumer {
+  subscriptions: {
+    create(params: object, mixin: object): CableSubscription;
+    remove(subscription: CableSubscription): void;
+  };
+}
+
+export interface ActionCableProviderOptions
+  extends Pick<SyncEngineOptions, "reliable" | "resendInterval" | "maxUnconfirmedResends" | "onFallback"> {
+  /** Awareness/presence instance. Defaults to a fresh `new Awareness(doc)`. */
+  awareness?: Awareness | null;
+}
+
+interface CableMessage {
+  m?: string;
+  update?: string;
+  ack?: number;
+}
+
+export class ActionCableProvider {
+  readonly doc: Doc;
+  readonly consumer: CableConsumer;
+  readonly channelName: string;
+  readonly channelParams: object;
+  readonly awareness: Awareness;
+  readonly engine: SyncEngine;
+  private subscription: CableSubscription | null = null;
+
+  constructor(
+    doc: Doc,
+    consumer: CableConsumer,
+    channelName: string,
+    channelParams: object = {},
+    opts: ActionCableProviderOptions = {}
+  ) {
+    this.doc = doc;
+    this.consumer = consumer;
+    this.channelName = channelName;
+    this.channelParams = channelParams;
+    this.awareness = opts.awareness ?? new Awareness(doc);
+
+    this.engine = new SyncEngine(doc, {
+      awareness: this.awareness,
+      reliable: opts.reliable,
+      resendInterval: opts.resendInterval,
+      maxUnconfirmedResends: opts.maxUnconfirmedResends,
+      onFallback: opts.onFallback,
+      send: (frame, id, sendOpts) => this._send(frame, id, sendOpts),
+    });
+  }
+
+  /** True once the document has caught up with the server (received a SyncStep2). */
+  get synced(): boolean {
+    return this.engine.synced;
+  }
+
+  /** True while there are unacknowledged local document updates in flight. */
+  get hasPending(): boolean {
+    return this.engine.hasPending;
+  }
+
+  connect(): void {
+    if (this.subscription) return;
+    const provider = this;
+    this.subscription = this.consumer.subscriptions.create(
+      { channel: this.channelName, ...this.channelParams },
+      {
+        received(message: CableMessage) {
+          // Reliable-delivery ack: confirm + prune the local queue.
+          if (message && message.ack !== undefined) {
+            provider.engine.ack(message.ack);
+            return;
+          }
+          const payload = message && (message.m ?? message.update);
+          if (typeof payload !== "string") return;
+          const reply = provider.engine.receive(fromBase64(payload));
+          if (reply) provider._send(reply, undefined); // e.g. SyncStep2 answering a SyncStep1
+        },
+        connected() {
+          provider.engine.onConnect(); // handshake + replay the unacked tail
+        },
+        disconnected() {
+          provider.engine.onDisconnect(); // pause retransmits, clear remote presence
+        },
+      }
+    );
+  }
+
+  disconnect(): void {
+    if (!this.subscription) return;
+    this.engine.onDisconnect();
+    this.consumer.subscriptions.remove(this.subscription);
+    this.subscription = null;
+  }
+
+  destroy(): void {
+    this.disconnect();
+    this.engine.destroy();
+  }
+
+  // Send one raw protocol frame over the cable. Awareness frames are whispered
+  // when the subscription supports it (AnyCable), else sent normally; document
+  // frames always go through `send`. `id` (reliable doc updates) is tagged onto
+  // the envelope so the server can ack. A no-op while disconnected: reliable
+  // frames stay queued in the engine and flush on the next connect().
+  private _send(frame: Uint8Array, id: number | undefined, opts?: SendOptions): void {
+    const sub = this.subscription;
+    if (!sub) return;
+    const update = toBase64(frame);
+    const payload = id === undefined ? { update } : { update, id };
+    const isAwareness = opts?.awareness ?? frame[0] === MessageType.Awareness;
+    if (isAwareness && typeof sub.whisper === "function") sub.whisper(payload);
+    else sub.send(payload);
+  }
+}

--- a/packages/yrb-lite-reliable/src/index.ts
+++ b/packages/yrb-lite-reliable/src/index.ts
@@ -5,7 +5,12 @@ export type { ReliableSyncOptions, TimerHandle } from "./reliable_sync.js";
 // Batteries-included protocol client (sync steps + encode/decode + awareness).
 // Requires `yjs` and `y-protocols` as peers.
 export { SyncEngine, MessageType } from "./sync_engine.js";
-export type { SyncEngineOptions } from "./sync_engine.js";
+export type { SyncEngineOptions, SendOptions } from "./sync_engine.js";
+
+// Ready-made ActionCable / AnyCable provider built on SyncEngine (with awareness
+// whisper support). Bring your own provider instead by composing SyncEngine.
+export { ActionCableProvider } from "./actioncable_provider.js";
+export type { ActionCableProviderOptions, CableConsumer, CableSubscription } from "./actioncable_provider.js";
 
 // Optional base64 helpers for transports that carry frames as strings.
 export { toBase64, fromBase64 } from "./base64.js";

--- a/packages/yrb-lite-reliable/src/sync_engine.ts
+++ b/packages/yrb-lite-reliable/src/sync_engine.ts
@@ -29,12 +29,24 @@ import { ReliableSync, type TimerHandle } from "./reliable_sync.js";
 
 export const MessageType = { Sync: 0, Awareness: 1, Auth: 2, QueryAwareness: 3 } as const;
 
+/** Hints about an outgoing frame, so the transport can route it appropriately. */
+export interface SendOptions {
+  /**
+   * True for awareness/presence frames. These are ephemeral and fire-and-forget,
+   * so a transport that supports it (e.g. AnyCable `whisper`) can broadcast them
+   * client-to-client without a server round-trip. Transports without that just
+   * send normally.
+   */
+  awareness?: boolean;
+}
+
 export interface SyncEngineOptions {
   /**
-   * Transmit one raw protocol frame; `id` is set only for reliable document
-   * updates (tag it onto your envelope so the server can ack).
+   * Transmit one raw protocol frame. `id` is set only for reliable document
+   * updates (tag it onto your envelope so the server can ack). `opts.awareness`
+   * marks presence frames so the transport can whisper them where supported.
    */
-  send: (frame: Uint8Array, id: number | undefined) => void;
+  send: (frame: Uint8Array, id: number | undefined, opts?: SendOptions) => void;
   /** Optional awareness/presence. When omitted, awareness frames are ignored. */
   awareness?: Awareness | null;
   /** Use ack-tracked reliable delivery (default true). */
@@ -102,7 +114,7 @@ export class SyncEngine {
     if (this.awareness) {
       this._onAwarenessUpdate = ({ added, updated, removed }: AwarenessChange) => {
         const changed = added.concat(updated, removed);
-        this._send(this._frameAwareness(changed), undefined); // presence: fire-and-forget
+        this._send(this._frameAwareness(changed), undefined, { awareness: true }); // fire-and-forget
       };
       this.awareness.on("update", this._onAwarenessUpdate);
     }
@@ -122,7 +134,7 @@ export class SyncEngine {
   onConnect(): void {
     this._send(this._frameSyncStep1(), undefined);
     if (this.awareness && this.awareness.getLocalState() !== null) {
-      this._send(this._frameAwareness([this.doc.clientID]), undefined);
+      this._send(this._frameAwareness([this.doc.clientID]), undefined, { awareness: true });
     }
     if (this.reliable) this._delivery.onConnect();
   }

--- a/packages/yrb-lite-reliable/test/actioncable_provider.test.js
+++ b/packages/yrb-lite-reliable/test/actioncable_provider.test.js
@@ -1,0 +1,109 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as Y from "yjs";
+import { Awareness } from "y-protocols/awareness";
+import { ActionCableProvider, MessageType, fromBase64 } from "../dist/index.js";
+
+// A fake ActionCable/AnyCable consumer. `withWhisper` toggles AnyCable's
+// client-to-client whisper method so we can test both routing paths.
+function fakeConsumer({ withWhisper } = { withWhisper: false }) {
+  const calls = { send: [], whisper: [] };
+  let sub = null;
+  const consumer = {
+    calls,
+    deliverConnected: () => sub.connected(),
+    deliverReceived: (msg) => sub.received(msg),
+    subscriptions: {
+      create(params, mixin) {
+        sub = {
+          identifier: JSON.stringify(params),
+          send: (data) => calls.send.push(data),
+          unsubscribe: () => {},
+          ...mixin,
+        };
+        if (withWhisper) sub.whisper = (data) => calls.whisper.push(data);
+        return sub;
+      },
+      remove: () => {},
+    },
+  };
+  return consumer;
+}
+
+const frameTypeOf = (b64) => fromBase64(b64)[0];
+
+// Create a provider and register failure-proof cleanup (a fresh Awareness starts
+// its own reaper interval, which would keep the event loop alive otherwise).
+function makeProvider(t, doc, consumer, params, opts) {
+  const p = new ActionCableProvider(doc, consumer, "DocumentChannel", params, opts);
+  t.after(() => {
+    p.destroy();
+    p.awareness.destroy();
+  });
+  return p;
+}
+
+test("constructs with a default awareness and exposes synced/hasPending", (t) => {
+  const p = makeProvider(t, new Y.Doc(), fakeConsumer(), { id: "r1" });
+  assert.ok(p.awareness instanceof Awareness, "a default Awareness is created");
+  assert.equal(p.synced, false);
+  assert.equal(p.hasPending, false);
+});
+
+test("on connect: the SyncStep1 handshake goes via normal send, never whisper", (t) => {
+  const c = fakeConsumer({ withWhisper: true });
+  const p = makeProvider(t, new Y.Doc(), c, { id: "r2" });
+  p.connect();
+  c.deliverConnected();
+  const sentSync = c.calls.send.filter((m) => frameTypeOf(m.update) === MessageType.Sync);
+  const whisperedSync = c.calls.whisper.filter((m) => frameTypeOf(m.update) === MessageType.Sync);
+  assert.ok(sentSync.length >= 1, "the SyncStep1 handshake was sent");
+  assert.equal(whisperedSync.length, 0, "no Sync frame is ever whispered (only awareness is)");
+});
+
+test("AnyCable: awareness frames are WHISPERED, document updates are SENT", (t) => {
+  const doc = new Y.Doc();
+  const c = fakeConsumer({ withWhisper: true });
+  const p = makeProvider(t, doc, c, { id: "r3" });
+  p.connect();
+  c.deliverConnected();
+
+  doc.getText("t").insert(0, "hello"); // a document update
+  p.awareness.setLocalStateField("user", "alice"); // a presence change
+
+  const docSends = c.calls.send.filter((m) => frameTypeOf(m.update) === MessageType.Sync);
+  const awarenessSends = c.calls.send.filter((m) => frameTypeOf(m.update) === MessageType.Awareness);
+  const awarenessWhispers = c.calls.whisper.filter((m) => frameTypeOf(m.update) === MessageType.Awareness);
+
+  assert.ok(docSends.length >= 1, "the document update went through send");
+  assert.equal(awarenessSends.length, 0, "no awareness frame went through send");
+  assert.ok(awarenessWhispers.length >= 1, "the presence change was whispered");
+});
+
+test("plain ActionCable (no whisper): awareness falls back to normal send", (t) => {
+  const doc = new Y.Doc();
+  const c = fakeConsumer({ withWhisper: false });
+  const p = makeProvider(t, doc, c, { id: "r4" });
+  p.connect();
+  c.deliverConnected();
+
+  p.awareness.setLocalStateField("user", "bob");
+
+  const awarenessSends = c.calls.send.filter((m) => frameTypeOf(m.update) === MessageType.Awareness);
+  assert.equal(c.calls.whisper.length, 0, "no whisper method, so nothing whispered");
+  assert.ok(awarenessSends.length >= 1, "presence still delivered, via normal send");
+});
+
+test("reliable doc updates carry an id; an ack drains the queue", (t) => {
+  const doc = new Y.Doc();
+  const c = fakeConsumer();
+  const p = makeProvider(t, doc, c, { id: "r5" });
+  p.connect();
+  c.deliverConnected();
+  doc.getText("t").insert(0, "x");
+  const docMsg = c.calls.send.find((m) => m.id !== undefined);
+  assert.ok(docMsg, "a reliable doc update is tagged with an id");
+  assert.equal(p.hasPending, true);
+  c.deliverReceived({ ack: docMsg.id });
+  assert.equal(p.hasPending, false, "the ack drained the pending queue");
+});

--- a/packages/yrb-lite-reliable/test/sync_engine.test.js
+++ b/packages/yrb-lite-reliable/test/sync_engine.test.js
@@ -148,6 +148,28 @@ test("two engines converge end-to-end through a relay", () => {
   assert.ok(docA.getText("t").toString().includes("from B"));
 });
 
+test("awareness frames are flagged { awareness: true } on the send callback; doc frames are not", () => {
+  const doc = new Y.Doc();
+  const awA = new Awareness(doc);
+  const sends = []; // [{ type, awareness }]
+  const eng = new SyncEngine(doc, {
+    awareness: awA,
+    ...noTimers,
+    send: (frame, _id, opts) => sends.push({ type: frameType(frame), awareness: !!(opts && opts.awareness) }),
+  });
+  eng.onConnect();
+  doc.getText("t").insert(0, "hi"); // document update
+  awA.setLocalStateField("user", "alice"); // presence
+
+  const sync = sends.filter((s) => s.type === MSG.Sync);
+  const awareness = sends.filter((s) => s.type === MSG.Awareness);
+  assert.ok(sync.length >= 1 && sync.every((s) => s.awareness === false), "Sync frames are NOT flagged awareness");
+  assert.ok(awareness.length >= 1 && awareness.every((s) => s.awareness === true), "Awareness frames ARE flagged");
+
+  eng.destroy();
+  awA.destroy();
+});
+
 test("awareness: a local presence change is framed; an incoming one is applied", () => {
   const docA = new Y.Doc();
   const awA = new Awareness(docA);


### PR DESCRIPTION
Two asks in one: give `yrb-lite-reliable` a real **provider** (not just primitives), and restore **AnyCable whisper** for awareness.

## ActionCableProvider
A ready-made ActionCable/AnyCable Yjs provider lives in the package now, composing `SyncEngine` — pure transport glue with a duck-typed consumer (no hard `@rails/actioncable` dep). `new ActionCableProvider(doc, consumer, channelName, channelParams, opts)` → `connect()` and you're collaborating. lexxy-realtime re-exports it as `YrbLiteProvider`, and `<lexxy-collaboration>` still accepts any provider, so apps can swap.

## Awareness whisper
Presence frames are flagged via a new `{ awareness }` option on `SyncEngine`'s `send` callback. The provider routes those over AnyCable's **`whisper`** (client-to-client, no server round-trip) when the subscription supports it, and falls back to a normal `send` on plain ActionCable. Document updates always go through `send` (they must be recorded/acked). This brings back the whisper behavior the old hand-rolled lexxy provider had — now in the package, opt-in by transport capability.

## Verification
- **24 `node:test` cases** (up from 18): provider whisper-routing **with** a whisper-capable consumer (awareness whispered, docs sent) and **without** (awareness falls back to send), ack-drains-queue, handshake-via-send, plus a SyncEngine test asserting awareness frames are flagged and Sync frames aren't.
- **lexxy-realtime's full real-server harness green** against the package provider — headless convergence/durability/reliable-delivery-under-loss + the real-browser Lexxy e2e (presence/cursors verified; exercises the whisper *fallback* path since the test server is plain ActionCable).
- `tsc` clean; `yjs`/`y-protocols` stay optional peers; `ReliableSync` stays zero-dep.

Bumps `yrb-lite-reliable` → **0.1.2**. lexxy-realtime → `0.1.0-alpha.2` (re-export of the package provider) is a follow-up publish in that repo; consumers on `^0.1.0` get 0.1.2 automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)