### PR TITLE
Make AnyCable awareness whisper opt-in (presence reliable by default)

### DIFF
--- a/packages/yrb-lite-reliable/README.md
+++ b/packages/yrb-lite-reliable/README.md
@@ -9,9 +9,11 @@ Three layers, use whichever you need:
 
 - **`ActionCableProvider`** — a ready-made Yjs provider for ActionCable /
   AnyCable. Pass a `Y.Doc`, a cable consumer, and a channel; it wires the
-  subscription and you're collaborating. Awareness/presence is **whispered** over
-  AnyCable (client-to-client, no server round-trip) and falls back to a normal
-  send on plain ActionCable.
+  subscription and you're collaborating. Presence is delivered reliably by
+  default (the server relays it). Pass `awarenessWhisper: true` to instead use
+  AnyCable's `whisper` (client-to-client, no server round-trip) — but only once
+  you've enabled whispering server-side (`stream_from key, whisper: true`),
+  otherwise AnyCable silently drops it.
 - **`SyncEngine`** — the transport-agnostic core. Binds to a `Y.Doc` (+ optional
   `Awareness`) and owns the y-protocols **message encode/decode**, the
   **sync-step handshake** (SyncStep1 / SyncStep2 / Update), **awareness**, and
@@ -57,9 +59,9 @@ provider.connect(); // does not auto-connect — wire your editor binding first
 
 On the server, include `YrbLite::ActionCable::Sync` in a channel named
 `DocumentChannel` (the [`yrb-lite-actioncable`](https://rubygems.org/gems/yrb-lite-actioncable)
-gem). Awareness/presence is whispered over AnyCable when available and sent
-normally on plain ActionCable. Need different transport or framing? Drop down to
-`SyncEngine` and supply your own `send`.
+gem). Presence is server-relayed by default; opt into AnyCable whisper with
+`awarenessWhisper: true` (see above). Need different transport or framing? Drop
+down to `SyncEngine` and supply your own `send`.
 
 ## SyncEngine
 

--- a/packages/yrb-lite-reliable/package-lock.json
+++ b/packages/yrb-lite-reliable/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yrb-lite-reliable",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yrb-lite-reliable",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.6.0",

--- a/packages/yrb-lite-reliable/package.json
+++ b/packages/yrb-lite-reliable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yrb-lite-reliable",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Client core for the yrb-lite y-websocket protocol: sync steps, message encode/decode, awareness, and reliable delivery (ack-tracked queue, sync-since-last-ack, retransmit + reconnect replay). Written in TypeScript with bundled types; usable from plain JS. Bring your own transport.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/yrb-lite-reliable/src/actioncable_provider.ts
+++ b/packages/yrb-lite-reliable/src/actioncable_provider.ts
@@ -38,6 +38,16 @@ export interface ActionCableProviderOptions
   extends Pick<SyncEngineOptions, "reliable" | "resendInterval" | "maxUnconfirmedResends" | "onFallback"> {
   /** Awareness/presence instance. Defaults to a fresh `new Awareness(doc)`. */
   awareness?: Awareness | null;
+  /**
+   * Send awareness/presence frames over AnyCable's `whisper` (client-to-client,
+   * no server round-trip) instead of a normal send. **Off by default**: whisper
+   * is silently dropped unless the server has enabled it for the stream
+   * (`stream_from key, whisper: true` under AnyCable), so the safe default
+   * delivers presence via a normal send that the server relays -- works on plain
+   * ActionCable and AnyCable alike. Turn this on only when you've enabled
+   * whispering server-side.
+   */
+  awarenessWhisper?: boolean;
 }
 
 interface CableMessage {
@@ -53,6 +63,7 @@ export class ActionCableProvider {
   readonly channelParams: object;
   readonly awareness: Awareness;
   readonly engine: SyncEngine;
+  private awarenessWhisper: boolean;
   private subscription: CableSubscription | null = null;
 
   constructor(
@@ -67,6 +78,7 @@ export class ActionCableProvider {
     this.channelName = channelName;
     this.channelParams = channelParams;
     this.awareness = opts.awareness ?? new Awareness(doc);
+    this.awarenessWhisper = opts.awarenessWhisper ?? false;
 
     this.engine = new SyncEngine(doc, {
       awareness: this.awareness,
@@ -138,7 +150,10 @@ export class ActionCableProvider {
     const update = toBase64(frame);
     const payload = id === undefined ? { update } : { update, id };
     const isAwareness = opts?.awareness ?? frame[0] === MessageType.Awareness;
-    if (isAwareness && typeof sub.whisper === "function") sub.whisper(payload);
+    // Awareness goes over whisper only when explicitly opted in AND the transport
+    // supports it; otherwise a normal send (which the server relays) so presence
+    // is never silently lost on a server that hasn't enabled whispering.
+    if (isAwareness && this.awarenessWhisper && typeof sub.whisper === "function") sub.whisper(payload);
     else sub.send(payload);
   }
 }

--- a/packages/yrb-lite-reliable/test/actioncable_provider.test.js
+++ b/packages/yrb-lite-reliable/test/actioncable_provider.test.js
@@ -61,10 +61,26 @@ test("on connect: the SyncStep1 handshake goes via normal send, never whisper", 
   assert.equal(whisperedSync.length, 0, "no Sync frame is ever whispered (only awareness is)");
 });
 
-test("AnyCable: awareness frames are WHISPERED, document updates are SENT", (t) => {
+test("default: awareness is SENT (not whispered) even when whisper is available", (t) => {
+  // Whisper is opt-in: by default presence goes over a normal send the server
+  // relays, so it's never lost on a server that hasn't enabled whispering.
   const doc = new Y.Doc();
   const c = fakeConsumer({ withWhisper: true });
   const p = makeProvider(t, doc, c, { id: "r3" });
+  p.connect();
+  c.deliverConnected();
+
+  p.awareness.setLocalStateField("user", "alice");
+
+  const awarenessSends = c.calls.send.filter((m) => frameTypeOf(m.update) === MessageType.Awareness);
+  assert.ok(awarenessSends.length >= 1, "presence went through a normal send by default");
+  assert.equal(c.calls.whisper.length, 0, "nothing whispered without opting in");
+});
+
+test("awarenessWhisper:true — awareness is WHISPERED, document updates are SENT", (t) => {
+  const doc = new Y.Doc();
+  const c = fakeConsumer({ withWhisper: true });
+  const p = makeProvider(t, doc, c, { id: "r3b" }, { awarenessWhisper: true });
   p.connect();
   c.deliverConnected();
 
@@ -80,10 +96,10 @@ test("AnyCable: awareness frames are WHISPERED, document updates are SENT", (t) 
   assert.ok(awarenessWhispers.length >= 1, "the presence change was whispered");
 });
 
-test("plain ActionCable (no whisper): awareness falls back to normal send", (t) => {
+test("awarenessWhisper:true but no whisper method: falls back to normal send", (t) => {
   const doc = new Y.Doc();
   const c = fakeConsumer({ withWhisper: false });
-  const p = makeProvider(t, doc, c, { id: "r4" });
+  const p = makeProvider(t, doc, c, { id: "r4" }, { awarenessWhisper: true });
   p.connect();
   c.deliverConnected();
 


### PR DESCRIPTION
**Found by intensive browser testing of realtime_talk against a real AnyCable stack.** Document edits synced, but **presence and remote cursors didn't propagate** — because `ActionCableProvider` sent awareness over AnyCable's `whisper`, and anycable-go **silently drops whispers unless the server enables them** (`stream_from key, whisper: true`; `--streams_whisper` defaults off). Whisper-by-default = silently-lost presence on any server that hasn't opted in.

## Fix
Awareness now defaults to a normal `send` (which `YrbLite::ActionCable::Sync` relays — works on plain ActionCable *and* AnyCable). Whisper is **opt-in** via a new option:
```js
new ActionCableProvider(doc, consumer, "DocumentChannel", { id }, { awarenessWhisper: true })
```
Only turn it on once you've enabled whispering server-side. `SyncEngine` still flags awareness frames; the provider decides the route.

## Verified
- 25 `node:test` cases (default = send even when whisper is available; `awarenessWhisper:true` whispers docs-sent; fallback to send when no whisper method).
- **realtime_talk e2e over the real AnyCable stack is now fully green** — presence over AnyCable, remote caret renders, selection highlight, convergence both ways, durability.

Bumps to **0.1.3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)