### PR TITLE
Rename sync_whisper -> awareness_whisper

### DIFF
--- a/CHANGELOG-actioncable.md
+++ b/CHANGELOG-actioncable.md
@@ -10,7 +10,7 @@ this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `sync_whisper` channel option (default off). When enabled and running under
+- `awareness_whisper` channel option (default off). When enabled and running under
   AnyCable, the channel enables client-to-client whispering on its stream
   (`stream_from key, whisper: true`), so a client that opts into whisper delivery
   (the JS provider's `awarenessWhisper: true`) has its presence frames broadcast

--- a/lib/yrb_lite/action_cable/sync.rb
+++ b/lib/yrb_lite/action_cable/sync.rb
@@ -108,15 +108,16 @@ module YrbLite::ActionCable # rubocop:disable Style/ClassAndModuleChildren
         @sync_backend || :memory
       end
 
-      # Enable AnyCable client-to-client whispering on this channel's stream (off
-      # by default). When on AND running under AnyCable, a client that opts into
-      # whisper delivery (the provider's `awarenessWhisper: true`) has its
-      # presence frames broadcast straight to other subscribers, no server
-      # round-trip. No effect on plain ActionCable (no whisper support; presence
-      # stays server-relayed). Document updates are never whispered.
-      def sync_whisper(value = nil)
-        @sync_whisper = value unless value.nil?
-        @sync_whisper || false
+      # Let awareness/presence frames travel over AnyCable's whisper -- broadcast
+      # straight to other subscribers with no server round-trip (off by default).
+      # When on AND running under AnyCable, the channel enables whispering on its
+      # stream so a client that opts in (the provider's `awarenessWhisper: true`)
+      # delivers presence this way. Only awareness is whispered; document updates
+      # always go through the server (recorded/acked). No effect on plain
+      # ActionCable (no whisper support; presence stays server-relayed).
+      def awareness_whisper(value = nil)
+        @awareness_whisper = value unless value.nil?
+        @awareness_whisper || false
       end
     end
 
@@ -414,12 +415,12 @@ module YrbLite::ActionCable # rubocop:disable Style/ClassAndModuleChildren
       sync_transmit(sync_load_doc.sync_step1)
     end
 
-    # Subscribe to the document's broadcast stream. When `sync_whisper` is on and
-    # the transport supports it (AnyCable adds `whispers_to`), enable
+    # Subscribe to the document's broadcast stream. When `awareness_whisper` is
+    # on and the transport supports it (AnyCable adds `whispers_to`), enable
     # client-to-client whispering on that stream; on plain ActionCable the option
     # is omitted (it isn't supported), so presence stays server-relayed.
     def sync_stream(name, **opts, &)
-      opts[:whisper] = true if self.class.sync_whisper && respond_to?(:whispers_to)
+      opts[:whisper] = true if self.class.awareness_whisper && respond_to?(:whispers_to)
       stream_from(name, **opts, &)
     end
 

--- a/test/sync_test.rb
+++ b/test/sync_test.rb
@@ -99,13 +99,13 @@ class SyncTest < Minitest::Test
     assert_equal :store, klass.sync_backend
   end
 
-  def test_sync_whisper_defaults_off_and_is_settable
+  def test_awareness_whisper_defaults_off_and_is_settable
     klass = Class.new { include YrbLite::ActionCable::Sync }
 
-    refute klass.sync_whisper
-    klass.sync_whisper true
+    refute klass.awareness_whisper
+    klass.awareness_whisper true
 
-    assert klass.sync_whisper
+    assert klass.awareness_whisper
   end
 
   # `whisper: true` is passed to stream_from only when whispering is opted in AND
@@ -119,7 +119,7 @@ class SyncTest < Minitest::Test
       define_method(:stream_from) { |_name, **opts, &_blk| captured << opts }
       define_method(:sync_stream_name) { "yrb_lite:doc" }
     end
-    klass.sync_whisper(whisper)
+    klass.awareness_whisper(whisper)
     instance = klass.new
     instance.define_singleton_method(:whispers_to) { |_b| nil } if anycable
     instance.send(:sync_stream, "yrb_lite:doc")


### PR DESCRIPTION
The channel option only affects awareness/presence (document updates are never whispered), so `awareness_whisper` names its scope and mirrors the JS provider's `awarenessWhisper`. Pure rename of the unpublished beta2 option; 95 ruby tests + rubocop green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)