### PR TITLE
Make AnyCable awareness whisper implicit on both sides

### DIFF
--- a/CHANGELOG-actioncable.md
+++ b/CHANGELOG-actioncable.md
@@ -10,13 +10,13 @@ this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `awareness_whisper` channel option (default off). When enabled and running under
-  AnyCable, the channel enables client-to-client whispering on its stream
-  (`stream_from key, whisper: true`), so a client that opts into whisper delivery
-  (the JS provider's `awarenessWhisper: true`) has its presence frames broadcast
-  directly to other subscribers with no server round-trip. It has no effect on
-  plain ActionCable (which has no whisper support), so presence there stays
-  server-relayed. Document updates are never whispered.
+- Automatic AnyCable whispering for awareness/presence. When running under
+  AnyCable, the channel now enables client-to-client whispering on its stream
+  (`stream_from key, whisper: true`), so a client that whispers awareness has its
+  presence frames broadcast directly to other subscribers with no server
+  round-trip. It's automatic -- no configuration -- and a no-op on plain
+  ActionCable (no whisper support), where presence stays server-relayed. Document
+  updates are never whispered.
 
 ## [0.1.0.beta1] - 2026-06-18
 

--- a/lib/yrb_lite/action_cable/sync.rb
+++ b/lib/yrb_lite/action_cable/sync.rb
@@ -107,18 +107,6 @@ module YrbLite::ActionCable # rubocop:disable Style/ClassAndModuleChildren
         @sync_backend = mode if mode
         @sync_backend || :memory
       end
-
-      # Let awareness/presence frames travel over AnyCable's whisper -- broadcast
-      # straight to other subscribers with no server round-trip (off by default).
-      # When on AND running under AnyCable, the channel enables whispering on its
-      # stream so a client that opts in (the provider's `awarenessWhisper: true`)
-      # delivers presence this way. Only awareness is whispered; document updates
-      # always go through the server (recorded/acked). No effect on plain
-      # ActionCable (no whisper support; presence stays server-relayed).
-      def awareness_whisper(value = nil)
-        @awareness_whisper = value unless value.nil?
-        @awareness_whisper || false
-      end
     end
 
     # Call from `subscribed`. Streams broadcasts for this document and
@@ -415,12 +403,14 @@ module YrbLite::ActionCable # rubocop:disable Style/ClassAndModuleChildren
       sync_transmit(sync_load_doc.sync_step1)
     end
 
-    # Subscribe to the document's broadcast stream. When `awareness_whisper` is
-    # on and the transport supports it (AnyCable adds `whispers_to`), enable
-    # client-to-client whispering on that stream; on plain ActionCable the option
-    # is omitted (it isn't supported), so presence stays server-relayed.
+    # Subscribe to the document's broadcast stream. Under AnyCable (which adds a
+    # `whispers_to` method) this also enables client-to-client whispering on the
+    # stream, so a client that whispers awareness (any AnyCable consumer can)
+    # reaches other subscribers with no server round-trip. On plain ActionCable
+    # the option is omitted -- there's no whisper support -- so presence is
+    # server-relayed. It's automatic either way; nothing to configure.
     def sync_stream(name, **opts, &)
-      opts[:whisper] = true if self.class.awareness_whisper && respond_to?(:whispers_to)
+      opts[:whisper] = true if respond_to?(:whispers_to)
       stream_from(name, **opts, &)
     end
 

--- a/packages/yrb-lite-reliable/README.md
+++ b/packages/yrb-lite-reliable/README.md
@@ -9,11 +9,11 @@ Three layers, use whichever you need:
 
 - **`ActionCableProvider`** — a ready-made Yjs provider for ActionCable /
   AnyCable. Pass a `Y.Doc`, a cable consumer, and a channel; it wires the
-  subscription and you're collaborating. Presence is delivered reliably by
-  default (the server relays it). Pass `awarenessWhisper: true` to instead use
-  AnyCable's `whisper` (client-to-client, no server round-trip) — but only once
-  you've enabled whispering server-side (`stream_from key, whisper: true`),
-  otherwise AnyCable silently drops it.
+  subscription and you're collaborating. Awareness/presence automatically rides
+  AnyCable's `whisper` when the consumer supports it (client-to-client, no server
+  round-trip), and falls back to a normal server-relayed send on plain
+  ActionCable — nothing to configure. Document updates always go through the
+  server (recorded/acked).
 - **`SyncEngine`** — the transport-agnostic core. Binds to a `Y.Doc` (+ optional
   `Awareness`) and owns the y-protocols **message encode/decode**, the
   **sync-step handshake** (SyncStep1 / SyncStep2 / Update), **awareness**, and
@@ -59,9 +59,9 @@ provider.connect(); // does not auto-connect — wire your editor binding first
 
 On the server, include `YrbLite::ActionCable::Sync` in a channel named
 `DocumentChannel` (the [`yrb-lite-actioncable`](https://rubygems.org/gems/yrb-lite-actioncable)
-gem). Presence is server-relayed by default; opt into AnyCable whisper with
-`awarenessWhisper: true` (see above). Need different transport or framing? Drop
-down to `SyncEngine` and supply your own `send`.
+gem), which enables AnyCable whispering on the stream automatically. Need a
+different transport or framing? Drop down to `SyncEngine` and supply your own
+`send`.
 
 ## SyncEngine
 

--- a/packages/yrb-lite-reliable/src/actioncable_provider.ts
+++ b/packages/yrb-lite-reliable/src/actioncable_provider.ts
@@ -38,16 +38,6 @@ export interface ActionCableProviderOptions
   extends Pick<SyncEngineOptions, "reliable" | "resendInterval" | "maxUnconfirmedResends" | "onFallback"> {
   /** Awareness/presence instance. Defaults to a fresh `new Awareness(doc)`. */
   awareness?: Awareness | null;
-  /**
-   * Send awareness/presence frames over AnyCable's `whisper` (client-to-client,
-   * no server round-trip) instead of a normal send. **Off by default**: whisper
-   * is silently dropped unless the server has enabled it for the stream
-   * (`stream_from key, whisper: true` under AnyCable), so the safe default
-   * delivers presence via a normal send that the server relays -- works on plain
-   * ActionCable and AnyCable alike. Turn this on only when you've enabled
-   * whispering server-side.
-   */
-  awarenessWhisper?: boolean;
 }
 
 interface CableMessage {
@@ -63,7 +53,6 @@ export class ActionCableProvider {
   readonly channelParams: object;
   readonly awareness: Awareness;
   readonly engine: SyncEngine;
-  private awarenessWhisper: boolean;
   private subscription: CableSubscription | null = null;
 
   constructor(
@@ -78,7 +67,6 @@ export class ActionCableProvider {
     this.channelName = channelName;
     this.channelParams = channelParams;
     this.awareness = opts.awareness ?? new Awareness(doc);
-    this.awarenessWhisper = opts.awarenessWhisper ?? false;
 
     this.engine = new SyncEngine(doc, {
       awareness: this.awareness,
@@ -150,10 +138,10 @@ export class ActionCableProvider {
     const update = toBase64(frame);
     const payload = id === undefined ? { update } : { update, id };
     const isAwareness = opts?.awareness ?? frame[0] === MessageType.Awareness;
-    // Awareness goes over whisper only when explicitly opted in AND the transport
-    // supports it; otherwise a normal send (which the server relays) so presence
-    // is never silently lost on a server that hasn't enabled whispering.
-    if (isAwareness && this.awarenessWhisper && typeof sub.whisper === "function") sub.whisper(payload);
+    // Awareness rides AnyCable's whisper automatically when the subscription
+    // supports it (client-to-client, no server round-trip); otherwise a normal
+    // send the server relays. Document updates always send (recorded/acked).
+    if (isAwareness && typeof sub.whisper === "function") sub.whisper(payload);
     else sub.send(payload);
   }
 }

--- a/packages/yrb-lite-reliable/test/actioncable_provider.test.js
+++ b/packages/yrb-lite-reliable/test/actioncable_provider.test.js
@@ -61,26 +61,11 @@ test("on connect: the SyncStep1 handshake goes via normal send, never whisper", 
   assert.equal(whisperedSync.length, 0, "no Sync frame is ever whispered (only awareness is)");
 });
 
-test("default: awareness is SENT (not whispered) even when whisper is available", (t) => {
-  // Whisper is opt-in: by default presence goes over a normal send the server
-  // relays, so it's never lost on a server that hasn't enabled whispering.
+test("AnyCable (whisper available): awareness is WHISPERED, document updates are SENT", (t) => {
+  // Automatic -- no flag: a whisper-capable subscription gets presence whispered.
   const doc = new Y.Doc();
   const c = fakeConsumer({ withWhisper: true });
   const p = makeProvider(t, doc, c, { id: "r3" });
-  p.connect();
-  c.deliverConnected();
-
-  p.awareness.setLocalStateField("user", "alice");
-
-  const awarenessSends = c.calls.send.filter((m) => frameTypeOf(m.update) === MessageType.Awareness);
-  assert.ok(awarenessSends.length >= 1, "presence went through a normal send by default");
-  assert.equal(c.calls.whisper.length, 0, "nothing whispered without opting in");
-});
-
-test("awarenessWhisper:true — awareness is WHISPERED, document updates are SENT", (t) => {
-  const doc = new Y.Doc();
-  const c = fakeConsumer({ withWhisper: true });
-  const p = makeProvider(t, doc, c, { id: "r3b" }, { awarenessWhisper: true });
   p.connect();
   c.deliverConnected();
 
@@ -93,13 +78,13 @@ test("awarenessWhisper:true — awareness is WHISPERED, document updates are SEN
 
   assert.ok(docSends.length >= 1, "the document update went through send");
   assert.equal(awarenessSends.length, 0, "no awareness frame went through send");
-  assert.ok(awarenessWhispers.length >= 1, "the presence change was whispered");
+  assert.ok(awarenessWhispers.length >= 1, "the presence change was whispered automatically");
 });
 
-test("awarenessWhisper:true but no whisper method: falls back to normal send", (t) => {
+test("plain ActionCable (no whisper): awareness falls back to normal send", (t) => {
   const doc = new Y.Doc();
   const c = fakeConsumer({ withWhisper: false });
-  const p = makeProvider(t, doc, c, { id: "r4" }, { awarenessWhisper: true });
+  const p = makeProvider(t, doc, c, { id: "r4" });
   p.connect();
   c.deliverConnected();
 

--- a/test/sync_test.rb
+++ b/test/sync_test.rb
@@ -99,19 +99,10 @@ class SyncTest < Minitest::Test
     assert_equal :store, klass.sync_backend
   end
 
-  def test_awareness_whisper_defaults_off_and_is_settable
-    klass = Class.new { include YrbLite::ActionCable::Sync }
-
-    refute klass.awareness_whisper
-    klass.awareness_whisper true
-
-    assert klass.awareness_whisper
-  end
-
-  # `whisper: true` is passed to stream_from only when whispering is opted in AND
-  # the transport supports it (AnyCable adds a `whispers_to` method); otherwise
-  # the option is omitted so plain ActionCable isn't handed an unknown kwarg.
-  def whisper_stream_opts(anycable:, whisper:)
+  # `whisper: true` is passed to stream_from automatically under AnyCable (which
+  # adds a `whispers_to` method), and omitted on plain ActionCable (where it
+  # isn't supported). No configuration either way.
+  def whisper_stream_opts(anycable:)
     captured = []
     klass = Class.new do
       include YrbLite::ActionCable::Sync
@@ -119,20 +110,17 @@ class SyncTest < Minitest::Test
       define_method(:stream_from) { |_name, **opts, &_blk| captured << opts }
       define_method(:sync_stream_name) { "yrb_lite:doc" }
     end
-    klass.awareness_whisper(whisper)
     instance = klass.new
     instance.define_singleton_method(:whispers_to) { |_b| nil } if anycable
     instance.send(:sync_stream, "yrb_lite:doc")
     captured.last
   end
 
-  def test_sync_stream_enables_whisper_only_under_anycable_when_opted_in
-    assert whisper_stream_opts(anycable: true, whisper: true)[:whisper],
-           "AnyCable + opted in -> whisper enabled"
-    refute whisper_stream_opts(anycable: false, whisper: true).key?(:whisper),
+  def test_sync_stream_enables_whisper_automatically_under_anycable
+    assert whisper_stream_opts(anycable: true)[:whisper],
+           "AnyCable -> whisper enabled automatically"
+    refute whisper_stream_opts(anycable: false).key?(:whisper),
            "plain ActionCable -> no whisper option"
-    refute whisper_stream_opts(anycable: true, whisper: false).key?(:whisper),
-           "not opted in -> no whisper even under AnyCable"
   end
 
   def test_store_backed_answers_sync_step1_from_the_store


### PR DESCRIPTION
Per feedback: drop the explicit toggles and make whisper implicit, the way yrb-actioncable does on the client — but auto-detect on **both** sides so they can't drift.

- **JS provider** (): awareness rides `whisper` whenever the subscription exposes a `whisper` method (any AnyCable consumer), else a normal send. No `awarenessWhisper` option.
- **gem** (`yrb-lite-actioncable`): `stream_from` enables whispering automatically when running under AnyCable (the anycable-rails ext adds `whispers_to`); a no-op on plain ActionCable. No `awareness_whisper` option.

Both auto-detect the same transport, so presence whispers under AnyCable and is server-relayed on plain ActionCable — nothing to configure. Document updates are never whispered. (An opt-out can be added later if anyone asks.)

**Verified end-to-end with zero flags** against a real AnyCable stack (realtime_talk): presence + remote cursors + selection all propagate via whisper. 24 JS + 94 ruby tests, rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)