### PR TITLE
Rename SyncEngine → YProtocolSession

### DIFF
--- a/packages/yrb-lite-client/README.md
+++ b/packages/yrb-lite-client/README.md
@@ -14,7 +14,7 @@ Three layers, use whichever you need:
   round-trip), and falls back to a normal server-relayed send on plain
   ActionCable — nothing to configure. Document updates always go through the
   server (recorded/acked).
-- **`SyncEngine`** — the transport-agnostic core. Binds to a `Y.Doc` (+ optional
+- **`YProtocolSession`** — the transport-agnostic core. Binds to a `Y.Doc` (+ optional
   `Awareness`) and owns the y-protocols **message encode/decode**, the
   **sync-step handshake** (SyncStep1 / SyncStep2 / Update), **awareness**, and
   reliable delivery. Speaks raw `Uint8Array` frames; you wire any socket.
@@ -30,7 +30,7 @@ Three layers, use whichever you need:
 npm install yrb-lite-client
 ```
 
-`ActionCableProvider` and `SyncEngine` need `yjs` and `y-protocols` (peers — your
+`ActionCableProvider` and `YProtocolSession` need `yjs` and `y-protocols` (peers — your
 app already has them), plus an ActionCable/AnyCable consumer. `ReliableSync` has
 **no dependencies**; import it on its own via `yrb-lite-client/reliable` if
 that's all you want.
@@ -60,20 +60,20 @@ provider.connect(); // does not auto-connect — wire your editor binding first
 On the server, include `YrbLite::ActionCable::Sync` in a channel named
 `DocumentChannel` (the [`yrb-lite-actioncable`](https://rubygems.org/gems/yrb-lite-actioncable)
 gem), which enables AnyCable whispering on the stream automatically. Need a
-different transport or framing? Drop down to `SyncEngine` and supply your own
+different transport or framing? Drop down to `YProtocolSession` and supply your own
 `send`.
 
-## SyncEngine
+## YProtocolSession
 
 ```js
-import { SyncEngine, toBase64, fromBase64 } from "yrb-lite-client";
+import { YProtocolSession, toBase64, fromBase64 } from "yrb-lite-client";
 import * as Y from "yjs";
 import { Awareness } from "y-protocols/awareness";
 
 const doc = new Y.Doc();
 const awareness = new Awareness(doc);
 
-const engine = new SyncEngine(doc, {
+const session = new YProtocolSession(doc, {
   awareness,
   // transmit one raw frame; `id` is set for reliable doc updates -> tag your envelope
   send: (frame, id) => {
@@ -84,15 +84,15 @@ const engine = new SyncEngine(doc, {
 });
 
 // wire your transport's callbacks:
-subscription.connected    = () => engine.onConnect();      // handshake + replay
-subscription.disconnected = () => engine.onDisconnect();   // pause + clear presence
+subscription.connected    = () => session.onConnect();      // handshake + replay
+subscription.disconnected = () => session.onDisconnect();   // pause + clear presence
 subscription.received = (msg) => {
-  if (msg.ack !== undefined) return engine.ack(msg.ack);   // reliable ack envelope
-  const reply = engine.receive(fromBase64(msg.update || msg.m)); // decode + apply
+  if (msg.ack !== undefined) return session.ack(msg.ack);   // reliable ack envelope
+  const reply = session.receive(fromBase64(msg.update || msg.m)); // decode + apply
   if (reply) subscription.send({ update: toBase64(reply) });     // e.g. answer a SyncStep1
 };
-// engine.synced -> caught up; engine.hasPending -> unacked edits in flight
-// engine.destroy() -> detach listeners + stop retransmits
+// session.synced -> caught up; session.hasPending -> unacked edits in flight
+// session.destroy() -> detach listeners + stop retransmits
 ```
 
 Local document edits and awareness changes are picked up automatically from the

--- a/packages/yrb-lite-client/package.json
+++ b/packages/yrb-lite-client/package.json
@@ -25,7 +25,8 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc",
+    "clean": "rm -rf dist",
+    "build": "npm run clean && tsc",
     "typecheck": "tsc --noEmit",
     "prepack": "npm run build",
     "test": "npm run build && node --test"

--- a/packages/yrb-lite-client/package.json
+++ b/packages/yrb-lite-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yrb-lite-client",
   "version": "0.1.1",
-  "description": "JavaScript client for the yrb-lite y-websocket protocol: a ready-made ActionCable/AnyCable provider, a transport-agnostic sync engine (sync steps, encode/decode, awareness), and a reliable-delivery core (ack-tracked queue, sync-since-last-ack, retransmit + reconnect replay). Written in TypeScript with bundled types; usable from plain JS.",
+  "description": "JavaScript client for the yrb-lite y-websocket protocol: a ready-made ActionCable/AnyCable provider, a transport-agnostic protocol session (sync steps, encode/decode, awareness), and a reliable-delivery core (ack-tracked queue, sync-since-last-ack, retransmit + reconnect replay). Written in TypeScript with bundled types; usable from plain JS.",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/yrb-lite-client/package.json
+++ b/packages/yrb-lite-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yrb-lite-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "JavaScript client for the yrb-lite y-websocket protocol: a ready-made ActionCable/AnyCable provider, a transport-agnostic sync engine (sync steps, encode/decode, awareness), and a reliable-delivery core (ack-tracked queue, sync-since-last-ack, retransmit + reconnect replay). Written in TypeScript with bundled types; usable from plain JS.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/yrb-lite-client/src/actioncable_provider.ts
+++ b/packages/yrb-lite-client/src/actioncable_provider.ts
@@ -2,7 +2,7 @@
 // ActionCable / AnyCable. It owns the cable subscription and translates between
 // the cable's JSON envelope (`{ update, id }` / `{ ack }`, base64) and raw
 // protocol frames; everything else (sync steps, encode/decode, awareness,
-// reliable delivery) lives in SyncEngine. So this is just the transport glue.
+// reliable delivery) lives in YProtocolSession. So this is just the transport glue.
 //
 // Awareness/presence frames are sent via AnyCable's `whisper` when the
 // subscription supports it (client-to-client, no server round-trip); on plain
@@ -13,7 +13,7 @@
 // The constructor does NOT auto-connect: wire your editor binding first, then
 // call `connect()`. Same `(doc, consumer, channelName, channelParams, opts)`
 // shape as a typical y-rb/actioncable provider.
-import { SyncEngine, MessageType, type SyncEngineOptions, type SendOptions } from "./sync_engine.js";
+import { YProtocolSession, MessageType, type YProtocolSessionOptions, type SendOptions } from "./y_protocol_session.js";
 import { toBase64, fromBase64 } from "./base64.js";
 import { Awareness } from "y-protocols/awareness";
 import type { Doc } from "yjs";
@@ -35,7 +35,7 @@ export interface CableConsumer {
 }
 
 export interface ActionCableProviderOptions
-  extends Pick<SyncEngineOptions, "reliable" | "resendInterval" | "maxUnconfirmedResends" | "onFallback"> {
+  extends Pick<YProtocolSessionOptions, "reliable" | "resendInterval" | "maxUnconfirmedResends" | "onFallback"> {
   /** Awareness/presence instance. Defaults to a fresh `new Awareness(doc)`. */
   awareness?: Awareness | null;
 }
@@ -52,7 +52,7 @@ export class ActionCableProvider {
   readonly channelName: string;
   readonly channelParams: object;
   readonly awareness: Awareness;
-  readonly engine: SyncEngine;
+  readonly session: YProtocolSession;
   private subscription: CableSubscription | null = null;
 
   constructor(
@@ -68,7 +68,7 @@ export class ActionCableProvider {
     this.channelParams = channelParams;
     this.awareness = opts.awareness ?? new Awareness(doc);
 
-    this.engine = new SyncEngine(doc, {
+    this.session = new YProtocolSession(doc, {
       awareness: this.awareness,
       reliable: opts.reliable,
       resendInterval: opts.resendInterval,
@@ -80,12 +80,12 @@ export class ActionCableProvider {
 
   /** True once the document has caught up with the server (received a SyncStep2). */
   get synced(): boolean {
-    return this.engine.synced;
+    return this.session.synced;
   }
 
   /** True while there are unacknowledged local document updates in flight. */
   get hasPending(): boolean {
-    return this.engine.hasPending;
+    return this.session.hasPending;
   }
 
   connect(): void {
@@ -97,19 +97,19 @@ export class ActionCableProvider {
         received(message: CableMessage) {
           // Reliable-delivery ack: confirm + prune the local queue.
           if (message && message.ack !== undefined) {
-            provider.engine.ack(message.ack);
+            provider.session.ack(message.ack);
             return;
           }
           const payload = message && (message.m ?? message.update);
           if (typeof payload !== "string") return;
-          const reply = provider.engine.receive(fromBase64(payload));
+          const reply = provider.session.receive(fromBase64(payload));
           if (reply) provider._send(reply, undefined); // e.g. SyncStep2 answering a SyncStep1
         },
         connected() {
-          provider.engine.onConnect(); // handshake + replay the unacked tail
+          provider.session.onConnect(); // handshake + replay the unacked tail
         },
         disconnected() {
-          provider.engine.onDisconnect(); // pause retransmits, clear remote presence
+          provider.session.onDisconnect(); // pause retransmits, clear remote presence
         },
       }
     );
@@ -117,21 +117,21 @@ export class ActionCableProvider {
 
   disconnect(): void {
     if (!this.subscription) return;
-    this.engine.onDisconnect();
+    this.session.onDisconnect();
     this.consumer.subscriptions.remove(this.subscription);
     this.subscription = null;
   }
 
   destroy(): void {
     this.disconnect();
-    this.engine.destroy();
+    this.session.destroy();
   }
 
   // Send one raw protocol frame over the cable. Awareness frames are whispered
   // when the subscription supports it (AnyCable), else sent normally; document
   // frames always go through `send`. `id` (reliable doc updates) is tagged onto
   // the envelope so the server can ack. A no-op while disconnected: reliable
-  // frames stay queued in the engine and flush on the next connect().
+  // frames stay queued in the session and flush on the next connect().
   private _send(frame: Uint8Array, id: number | undefined, opts?: SendOptions): void {
     const sub = this.subscription;
     if (!sub) return;

--- a/packages/yrb-lite-client/src/index.ts
+++ b/packages/yrb-lite-client/src/index.ts
@@ -2,13 +2,13 @@
 export { ReliableSync } from "./reliable_sync.js";
 export type { ReliableSyncOptions, TimerHandle } from "./reliable_sync.js";
 
-// Batteries-included protocol client (sync steps + encode/decode + awareness).
+// Batteries-included protocol session (sync steps + encode/decode + awareness).
 // Requires `yjs` and `y-protocols` as peers.
-export { SyncEngine, MessageType } from "./sync_engine.js";
-export type { SyncEngineOptions, SendOptions } from "./sync_engine.js";
+export { YProtocolSession, MessageType } from "./y_protocol_session.js";
+export type { YProtocolSessionOptions, SendOptions } from "./y_protocol_session.js";
 
-// Ready-made ActionCable / AnyCable provider built on SyncEngine (with awareness
-// whisper support). Bring your own provider instead by composing SyncEngine.
+// Ready-made ActionCable / AnyCable provider built on YProtocolSession (with awareness
+// whisper support). Bring your own provider instead by composing YProtocolSession.
 export { ActionCableProvider } from "./actioncable_provider.js";
 export type { ActionCableProviderOptions, CableConsumer, CableSubscription } from "./actioncable_provider.js";
 

--- a/packages/yrb-lite-client/src/y_protocol_session.ts
+++ b/packages/yrb-lite-client/src/y_protocol_session.ts
@@ -1,6 +1,7 @@
-// A batteries-included client core for the yrb-lite y-websocket protocol.
+// A batteries-included, transport-agnostic session for the yrb-lite
+// y-websocket protocol.
 //
-// SyncEngine composes ReliableSync and additionally owns the parts a provider
+// YProtocolSession composes ReliableSync and additionally owns the parts a provider
 // would otherwise re-implement: the y-protocols message framing (encode/decode),
 // the sync-step handshake (SyncStep1 / SyncStep2 / Update), and awareness
 // encode/apply. It binds to a Y.Doc (and optional Awareness) and speaks in raw
@@ -40,7 +41,7 @@ export interface SendOptions {
   awareness?: boolean;
 }
 
-export interface SyncEngineOptions {
+export interface YProtocolSessionOptions {
   /**
    * Transmit one raw protocol frame. `id` is set only for reliable document
    * updates (tag it onto your envelope so the server can ack). `opts.awareness`
@@ -64,18 +65,18 @@ export interface SyncEngineOptions {
 
 type AwarenessChange = { added: number[]; updated: number[]; removed: number[] };
 
-export class SyncEngine {
+export class YProtocolSession {
   readonly doc: Doc;
   readonly awareness: Awareness | null;
   reliable: boolean;
 
-  private _send: SyncEngineOptions["send"];
+  private _send: YProtocolSessionOptions["send"];
   private _synced = false;
   private _delivery: ReliableSync;
   private _onDocUpdate: (update: Uint8Array, origin: unknown) => void;
   private _onAwarenessUpdate?: (change: AwarenessChange, origin: unknown) => void;
 
-  constructor(doc: Doc, opts: SyncEngineOptions) {
+  constructor(doc: Doc, opts: YProtocolSessionOptions) {
     const {
       send,
       awareness = null,
@@ -85,9 +86,9 @@ export class SyncEngine {
       onFallback,
       setInterval: setIntervalFn,
       clearInterval: clearIntervalFn,
-    } = opts ?? ({} as SyncEngineOptions);
-    if (!doc) throw new TypeError("SyncEngine requires a Y.Doc");
-    if (typeof send !== "function") throw new TypeError("SyncEngine requires a send(frame, id) function");
+    } = opts ?? ({} as YProtocolSessionOptions);
+    if (!doc) throw new TypeError("YProtocolSession requires a Y.Doc");
+    if (typeof send !== "function") throw new TypeError("YProtocolSession requires a send(frame, id) function");
 
     this.doc = doc;
     this.awareness = awareness;

--- a/packages/yrb-lite-client/test/y_protocol_session.test.js
+++ b/packages/yrb-lite-client/test/y_protocol_session.test.js
@@ -4,7 +4,7 @@ import * as Y from "yjs";
 import * as encoding from "lib0/encoding";
 import { writeSyncStep1, writeUpdate } from "y-protocols/sync";
 import { Awareness, encodeAwarenessUpdate } from "y-protocols/awareness";
-import { SyncEngine, MessageType } from "../dist/sync_engine.js";
+import { YProtocolSession, MessageType } from "../dist/y_protocol_session.js";
 
 const MSG = MessageType;
 
@@ -17,7 +17,7 @@ const noTimers = { setInterval: () => 0, clearInterval: () => {} };
 function engine(opts = {}) {
   const doc = new Y.Doc();
   const sent = []; // [{ frame, id }]
-  const eng = new SyncEngine(doc, { send: (frame, id) => sent.push({ frame, id }), ...noTimers, ...opts });
+  const eng = new YProtocolSession(doc, { send: (frame, id) => sent.push({ frame, id }), ...noTimers, ...opts });
   return { doc, eng, sent };
 }
 
@@ -36,8 +36,8 @@ function updateFrame(update) {
 }
 
 test("requires a doc and a send function", () => {
-  assert.throws(() => new SyncEngine(null, { send: () => {} }), /Y\.Doc/);
-  assert.throws(() => new SyncEngine(new Y.Doc(), {}), /send/);
+  assert.throws(() => new YProtocolSession(null, { send: () => {} }), /Y\.Doc/);
+  assert.throws(() => new YProtocolSession(new Y.Doc(), {}), /send/);
 });
 
 test("onConnect emits a SyncStep1 handshake frame", () => {
@@ -122,14 +122,14 @@ test("two engines converge end-to-end through a relay", () => {
     // reply (e.g. SyncStep2) goes back to the sender's peer as well
     return reply;
   };
-  a = new SyncEngine(docA, {
+  a = new YProtocolSession(docA, {
     reliable: false,
     send: (frame) => {
       const reply = b.receive(frame);
       if (reply) a.receive(reply);
     },
   });
-  b = new SyncEngine(docB, {
+  b = new YProtocolSession(docB, {
     reliable: false,
     send: (frame) => {
       const reply = a.receive(frame);
@@ -152,7 +152,7 @@ test("awareness frames are flagged { awareness: true } on the send callback; doc
   const doc = new Y.Doc();
   const awA = new Awareness(doc);
   const sends = []; // [{ type, awareness }]
-  const eng = new SyncEngine(doc, {
+  const eng = new YProtocolSession(doc, {
     awareness: awA,
     ...noTimers,
     send: (frame, _id, opts) => sends.push({ type: frameType(frame), awareness: !!(opts && opts.awareness) }),
@@ -174,7 +174,7 @@ test("awareness: a local presence change is framed; an incoming one is applied",
   const docA = new Y.Doc();
   const awA = new Awareness(docA);
   const sentA = [];
-  const engA = new SyncEngine(docA, { awareness: awA, send: (frame, id) => sentA.push({ frame, id }) });
+  const engA = new YProtocolSession(docA, { awareness: awA, send: (frame, id) => sentA.push({ frame, id }) });
 
   awA.setLocalStateField("user", "alice");
   const awarenessFrame = sentA.find((s) => frameType(s.frame) === MSG.Awareness);
@@ -184,7 +184,7 @@ test("awareness: a local presence change is framed; an incoming one is applied",
   // Apply alice's presence into a second engine's awareness.
   const docB = new Y.Doc();
   const awB = new Awareness(docB);
-  const engB = new SyncEngine(docB, { awareness: awB, send: () => {} });
+  const engB = new YProtocolSession(docB, { awareness: awB, send: () => {} });
   const e = encoding.createEncoder();
   encoding.writeVarUint(e, MSG.Awareness);
   encoding.writeVarUint8Array(e, encodeAwarenessUpdate(awA, [docA.clientID]));


### PR DESCRIPTION
`SyncEngine` was a vague name — *everything* in this package syncs. The class is the **transport-agnostic, doc-bound session** that owns y-protocols framing, the sync-step handshake (SyncStep1/2/Update), and awareness encode/apply. You drive its `onConnect`/`onDisconnect`/`ack`/`receive` lifecycle from a transport; it owns no socket — the *provider* is the actual client. `Session` captures the lifecycle + state; `client` overclaimed.

## Changes
- `class SyncEngine` → `YProtocolSession`; `SyncEngineOptions` → `YProtocolSessionOptions`
- `src/sync_engine.ts` → `src/y_protocol_session.ts` (+ test file)
- `ActionCableProvider.engine` → `.session`
- Harden the build: `clean` (rm -rf dist) before `tsc`, so renamed modules don't leave orphaned `sync_engine.js` in the published tarball
- README + doc comments updated; dropped the "client" framing for the class

## Surface impact
Contained. No consumer imports the class by name — `ActionCableProvider` is the public entry point, and lexxy-realtime uses *that*. The published `yrb-lite-client@0.1.0` exported `SyncEngine`, so a republish under a new version is needed to ship the rename (no in-tree consumer breaks).

## Verification
- `npm run build` clean (tsc, no errors); dist has no `sync_engine.*` orphans
- `node --test`: **24/24 pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)