### PR TITLE
Defensive receive() + onError hook

### DIFF
--- a/packages/yrb-lite-client/README.md
+++ b/packages/yrb-lite-client/README.md
@@ -98,6 +98,11 @@ subscription.received = (msg) => {
 Local document edits and awareness changes are picked up automatically from the
 doc's / awareness's `update` events — you never call anything for outbound edits.
 
+Pass `onError(error, context)` (on either `ActionCableProvider` or
+`YProtocolSession`) to observe dropped frames: a malformed or truncated message
+is decoded defensively, dropped, and reported here rather than thrown into your
+transport callback. Defaults to a `console.warn`.
+
 ## ReliableSync (standalone)
 
 ```js

--- a/packages/yrb-lite-client/package-lock.json
+++ b/packages/yrb-lite-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yrb-lite-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yrb-lite-client",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.6.0",

--- a/packages/yrb-lite-client/src/actioncable_provider.ts
+++ b/packages/yrb-lite-client/src/actioncable_provider.ts
@@ -35,7 +35,10 @@ export interface CableConsumer {
 }
 
 export interface ActionCableProviderOptions
-  extends Pick<YProtocolSessionOptions, "reliable" | "resendInterval" | "maxUnconfirmedResends" | "onFallback"> {
+  extends Pick<
+    YProtocolSessionOptions,
+    "reliable" | "resendInterval" | "maxUnconfirmedResends" | "onFallback" | "onError"
+  > {
   /** Awareness/presence instance. Defaults to a fresh `new Awareness(doc)`. */
   awareness?: Awareness | null;
 }
@@ -54,6 +57,7 @@ export class ActionCableProvider {
   readonly awareness: Awareness;
   readonly session: YProtocolSession;
   private subscription: CableSubscription | null = null;
+  private _onError: (error: unknown, context: string) => void;
 
   constructor(
     doc: Doc,
@@ -67,6 +71,7 @@ export class ActionCableProvider {
     this.channelName = channelName;
     this.channelParams = channelParams;
     this.awareness = opts.awareness ?? new Awareness(doc);
+    this._onError = opts.onError ?? ((error, context) => console.warn(`[yrb-lite] ${context}:`, error));
 
     this.session = new YProtocolSession(doc, {
       awareness: this.awareness,
@@ -74,6 +79,7 @@ export class ActionCableProvider {
       resendInterval: opts.resendInterval,
       maxUnconfirmedResends: opts.maxUnconfirmedResends,
       onFallback: opts.onFallback,
+      onError: this._onError,
       send: (frame, id, sendOpts) => this._send(frame, id, sendOpts),
     });
   }
@@ -102,7 +108,16 @@ export class ActionCableProvider {
           }
           const payload = message && (message.m ?? message.update);
           if (typeof payload !== "string") return;
-          const reply = provider.session.receive(fromBase64(payload));
+          // Guard base64 decode too: a malformed envelope must not throw into
+          // the cable callback (session.receive is itself defensive).
+          let frame: Uint8Array;
+          try {
+            frame = fromBase64(payload);
+          } catch (error) {
+            provider._onError(error, "received");
+            return;
+          }
+          const reply = provider.session.receive(frame);
           if (reply) provider._send(reply, undefined); // e.g. SyncStep2 answering a SyncStep1
         },
         connected() {

--- a/packages/yrb-lite-client/src/y_protocol_session.ts
+++ b/packages/yrb-lite-client/src/y_protocol_session.ts
@@ -58,6 +58,13 @@ export interface YProtocolSessionOptions {
   maxUnconfirmedResends?: number;
   /** Forwarded to ReliableSync. */
   onFallback?: () => void;
+  /**
+   * Called when an incoming frame can't be decoded/applied (malformed bytes,
+   * truncated message, unexpected structure). The frame is dropped and the
+   * session keeps running. `context` names where it happened (e.g. "receive").
+   * Defaults to a `console.warn`.
+   */
+  onError?: (error: unknown, context: string) => void;
   /** Injectable timer hooks (forwarded to ReliableSync); handy for tests. */
   setInterval?: (handler: () => void, ms: number) => TimerHandle;
   clearInterval?: (handle: TimerHandle) => void;
@@ -71,6 +78,7 @@ export class YProtocolSession {
   reliable: boolean;
 
   private _send: YProtocolSessionOptions["send"];
+  private _onError: (error: unknown, context: string) => void;
   private _synced = false;
   private _delivery: ReliableSync;
   private _onDocUpdate: (update: Uint8Array, origin: unknown) => void;
@@ -84,6 +92,7 @@ export class YProtocolSession {
       resendInterval,
       maxUnconfirmedResends,
       onFallback,
+      onError,
       setInterval: setIntervalFn,
       clearInterval: clearIntervalFn,
     } = opts ?? ({} as YProtocolSessionOptions);
@@ -94,6 +103,7 @@ export class YProtocolSession {
     this.awareness = awareness;
     this.reliable = reliable;
     this._send = send;
+    this._onError = onError ?? ((error, context) => console.warn(`[yrb-lite] ${context}:`, error));
 
     this._delivery = new ReliableSync({
       merge: mergeUpdates,
@@ -161,34 +171,41 @@ export class YProtocolSession {
    * SyncStep1, or an awareness reply to a query), or null if there's nothing to send.
    */
   receive(frame: Uint8Array): Uint8Array | null {
-    const decoder = decoding.createDecoder(frame);
-    const encoder = encoding.createEncoder();
-    const type = decoding.readVarUint(decoder);
-    switch (type) {
-      case MessageType.Sync: {
-        encoding.writeVarUint(encoder, MessageType.Sync);
-        const syncType = readSyncMessage(decoder, encoder, this.doc, this);
-        if (!this._synced && syncType === messageYjsSyncStep2) this._synced = true;
-        break;
+    // A malformed/truncated frame must never take down the transport callback:
+    // decode + apply defensively, drop the frame on error, keep the session live.
+    try {
+      const decoder = decoding.createDecoder(frame);
+      const encoder = encoding.createEncoder();
+      const type = decoding.readVarUint(decoder);
+      switch (type) {
+        case MessageType.Sync: {
+          encoding.writeVarUint(encoder, MessageType.Sync);
+          const syncType = readSyncMessage(decoder, encoder, this.doc, this);
+          if (!this._synced && syncType === messageYjsSyncStep2) this._synced = true;
+          break;
+        }
+        case MessageType.Awareness:
+          if (this.awareness) applyAwarenessUpdate(this.awareness, decoding.readVarUint8Array(decoder), this);
+          return null;
+        case MessageType.QueryAwareness:
+          if (!this.awareness) return null;
+          encoding.writeVarUint(encoder, MessageType.Awareness);
+          encoding.writeVarUint8Array(
+            encoder,
+            encodeAwarenessUpdate(this.awareness, [...this.awareness.getStates().keys()])
+          );
+          break;
+        case MessageType.Auth:
+          readAuthMessage(decoder, this.doc, (_doc, reason) => console.warn(`[yrb-lite] auth denied: ${reason}`));
+          return null;
+        default:
+          return null; // unknown message type: ignore
       }
-      case MessageType.Awareness:
-        if (this.awareness) applyAwarenessUpdate(this.awareness, decoding.readVarUint8Array(decoder), this);
-        return null;
-      case MessageType.QueryAwareness:
-        if (!this.awareness) return null;
-        encoding.writeVarUint(encoder, MessageType.Awareness);
-        encoding.writeVarUint8Array(
-          encoder,
-          encodeAwarenessUpdate(this.awareness, [...this.awareness.getStates().keys()])
-        );
-        break;
-      case MessageType.Auth:
-        readAuthMessage(decoder, this.doc, (_doc, reason) => console.warn(`[yrb-lite] auth denied: ${reason}`));
-        return null;
-      default:
-        return null;
+      return encoding.length(encoder) > 1 ? encoding.toUint8Array(encoder) : null;
+    } catch (error) {
+      this._onError(error, "receive");
+      return null;
     }
-    return encoding.length(encoder) > 1 ? encoding.toUint8Array(encoder) : null;
   }
 
   /** Detach doc/awareness listeners and stop retransmits. */

--- a/packages/yrb-lite-client/test/y_protocol_session.test.js
+++ b/packages/yrb-lite-client/test/y_protocol_session.test.js
@@ -203,3 +203,39 @@ function writeSyncStep2FromPeer(encoder, peer) {
   encoding.writeVarUint(encoder, 1);
   encoding.writeVarUint8Array(encoder, Y.encodeStateAsUpdate(peer));
 }
+
+test("receive: a malformed frame is dropped, not thrown, and reports via onError", () => {
+  const errors = [];
+  const doc = new Y.Doc();
+  const eng = new YProtocolSession(doc, {
+    ...noTimers,
+    send: () => {},
+    onError: (err, context) => errors.push({ err, context }),
+  });
+
+  // A Sync frame whose body is garbage (claims more bytes than it carries).
+  const bad = Uint8Array.from([MSG.Sync, 0xff, 0xff, 0xff, 0xff]);
+  let reply;
+  assert.doesNotThrow(() => {
+    reply = eng.receive(bad);
+  }, "a malformed frame must not throw into the transport callback");
+  assert.equal(reply, null, "nothing to send back for a dropped frame");
+  assert.equal(errors.length, 1, "onError fired once");
+  assert.equal(errors[0].context, "receive", "context names where it failed");
+
+  // The session is still live: a valid frame afterwards still works.
+  assert.doesNotThrow(() => eng.receive(syncStep1Frame(new Y.Doc())));
+  eng.destroy();
+});
+
+test("receive: an unknown message type is ignored without error", () => {
+  const errors = [];
+  const { eng } = engine({ onError: (err, context) => errors.push({ err, context }) });
+  const e = encoding.createEncoder();
+  encoding.writeVarUint(e, 99); // not a known MessageType
+  encoding.writeVarUint8Array(e, Uint8Array.from([1, 2, 3]));
+  const reply = eng.receive(encoding.toUint8Array(e));
+  assert.equal(reply, null, "unknown type yields no reply");
+  assert.equal(errors.length, 0, "unknown type is not an error, just ignored");
+  eng.destroy();
+});


### PR DESCRIPTION
First of the upstream-into-the-client changes from review feedback: make the provider robust to bad input.

## Problem
`YProtocolSession.receive()` decoded with no `try/catch`, and the provider's `fromBase64` ran *before* `receive()` — so a malformed, truncated, or non-base64 frame threw straight into the cable's `received()` callback, which can wedge the subscription.

## Change
- `receive()` wraps decode + apply; a bad frame is **dropped**, the session stays live, and the error is reported via a new **`onError(error, context)`** hook (default `console.warn`).
- `ActionCableProvider` guards `fromBase64` → `onError(err, 'received')`, and threads `onError` down to the session.
- Unknown message types remain a silent ignore (not an error).
- Also synced the lockfile `version` to 0.1.1 (the bump PR missed it).

## Tests
- malformed frame: no throw, dropped, `onError` fires with context `'receive'`, session still usable afterward
- unknown message type: ignored, no error
- 26/26 pass

Part of the series: (1) **defensive receive + onError** ← this, (2) connection-status events, (3) awareness teardown + ownership/autoConnect/beforeunload, (4) collapse lexxy to a thin adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)