### PR TITLE
Connection status events + implicit awareness teardown

### DIFF
--- a/packages/yrb-lite-client/README.md
+++ b/packages/yrb-lite-client/README.md
@@ -51,11 +51,28 @@ const consumer = createConsumer();
 const provider = new ActionCableProvider(doc, consumer, "DocumentChannel", { id: docId });
 
 provider.connect(); // does not auto-connect — wire your editor binding first
+
+// Observe the connection (one signal, no separate "sync" event):
+provider.on("status", ({ status }) => render(status));
+//   "connecting"  -> subscription created, transport not up yet
+//   "connected"   -> transport up, exchanging sync steps (show "syncing")
+//   "synced"      -> caught up with the server
+//   "disconnected"-> torn down via disconnect()/destroy()
+//                    (a dropped transport ActionCable will retry shows as "connecting")
+
+// provider.status     -> the current status (same union as above)
 // provider.awareness  -> the Awareness instance (a fresh one unless you pass opts.awareness)
 // provider.synced     -> caught up with the server
 // provider.hasPending -> unacked local edits in flight
 // provider.destroy()  -> tear down
 ```
+
+On `disconnect()` / `destroy()` — and on browser `pagehide` — the provider
+broadcasts a presence removal so peers drop your cursor immediately instead of
+waiting for the awareness timeout. `destroy()` is synchronous (the unsubscribe is
+deferred one microtask so that removal flushes first) and tears down the
+`Awareness` only if the provider created it; a `Awareness` you pass in is yours
+to own.
 
 On the server, include `YrbLite::ActionCable::Sync` in a channel named
 `DocumentChannel` (the [`yrb-lite-actioncable`](https://rubygems.org/gems/yrb-lite-actioncable)

--- a/packages/yrb-lite-client/src/actioncable_provider.ts
+++ b/packages/yrb-lite-client/src/actioncable_provider.ts
@@ -13,10 +13,31 @@
 // The constructor does NOT auto-connect: wire your editor binding first, then
 // call `connect()`. Same `(doc, consumer, channelName, channelParams, opts)`
 // shape as a typical y-rb/actioncable provider.
+//
+// Observe the connection with `provider.on("status", ({ status }) => ...)`
+// (`"connecting" | "connected" | "synced" | "disconnected"`) or the `status`
+// getter. On `disconnect()` / `destroy()` -- and on browser `pagehide` -- the
+// provider broadcasts a presence removal so peers drop our cursor immediately
+// instead of waiting for the awareness timeout.
 import { YProtocolSession, MessageType, type YProtocolSessionOptions, type SendOptions } from "./y_protocol_session.js";
 import { toBase64, fromBase64 } from "./base64.js";
 import { Awareness } from "y-protocols/awareness";
 import type { Doc } from "yjs";
+
+/**
+ * Connection lifecycle, folded into one signal (no separate "sync" event):
+ *   connecting   -- subscription created, transport not up yet
+ *   connected    -- transport up, exchanging sync steps (UI: "syncing")
+ *   synced       -- caught up with the server
+ *   disconnected -- torn down via disconnect()/destroy() (a dropped transport
+ *                   that ActionCable will retry shows as "connecting")
+ */
+export type ProviderStatus = "connecting" | "connected" | "synced" | "disconnected";
+
+/** Payload for the `"status"` event. */
+export interface StatusEvent {
+  status: ProviderStatus;
+}
 
 /** The minimal slice of an ActionCable/AnyCable subscription this provider uses. */
 export interface CableSubscription {
@@ -58,6 +79,11 @@ export class ActionCableProvider {
   readonly session: YProtocolSession;
   private subscription: CableSubscription | null = null;
   private _onError: (error: unknown, context: string) => void;
+  private _ownsAwareness: boolean;
+  private _connected = false;
+  private _status: ProviderStatus = "disconnected";
+  private _statusListeners = new Set<(event: StatusEvent) => void>();
+  private _onUnload: (() => void) | null = null;
 
   constructor(
     doc: Doc,
@@ -70,6 +96,7 @@ export class ActionCableProvider {
     this.consumer = consumer;
     this.channelName = channelName;
     this.channelParams = channelParams;
+    this._ownsAwareness = opts.awareness == null;
     this.awareness = opts.awareness ?? new Awareness(doc);
     this._onError = opts.onError ?? ((error, context) => console.warn(`[yrb-lite] ${context}:`, error));
 
@@ -92,6 +119,23 @@ export class ActionCableProvider {
   /** True while there are unacknowledged local document updates in flight. */
   get hasPending(): boolean {
     return this.session.hasPending;
+  }
+
+  /** Current connection status. See {@link ProviderStatus}. */
+  get status(): ProviderStatus {
+    return this._status;
+  }
+
+  /** Subscribe to status changes. Returns an unsubscribe function. */
+  on(event: "status", listener: (event: StatusEvent) => void): () => void {
+    if (event !== "status") return () => {};
+    this._statusListeners.add(listener);
+    return () => this._statusListeners.delete(listener);
+  }
+
+  /** Remove a previously-registered status listener. */
+  off(event: "status", listener: (event: StatusEvent) => void): void {
+    if (event === "status") this._statusListeners.delete(listener);
   }
 
   connect(): void {
@@ -119,27 +163,75 @@ export class ActionCableProvider {
           }
           const reply = provider.session.receive(frame);
           if (reply) provider._send(reply, undefined); // e.g. SyncStep2 answering a SyncStep1
+          provider._refreshStatus(); // a SyncStep2 may have just flipped us to "synced"
         },
         connected() {
+          provider._connected = true;
           provider.session.onConnect(); // handshake + replay the unacked tail
+          provider._refreshStatus();
         },
         disconnected() {
+          provider._connected = false;
           provider.session.onDisconnect(); // pause retransmits, clear remote presence
+          provider._refreshStatus(); // subscription still set -> "connecting" (retrying)
         },
       }
     );
+    this._installUnloadHandler();
+    this._refreshStatus(); // -> "connecting"
   }
 
   disconnect(): void {
     if (!this.subscription) return;
+    const sub = this.subscription;
+    // Tell peers we're gone while the transport is still live, then pause and
+    // detach. Defer the unsubscribe one microtask so the removal frame flushes
+    // before the channel tears down.
+    this.session.removeLocalAwareness();
     this.session.onDisconnect();
-    this.consumer.subscriptions.remove(this.subscription);
+    this._connected = false;
     this.subscription = null;
+    this._removeUnloadHandler();
+    queueMicrotask(() => this.consumer.subscriptions.remove(sub));
+    this._refreshStatus(); // -> "disconnected"
   }
 
   destroy(): void {
     this.disconnect();
     this.session.destroy();
+    // Only tear down the Awareness if we created it; a caller-supplied one is
+    // theirs to own (and destroying it stops its reaper timer either way).
+    if (this._ownsAwareness) this.awareness.destroy();
+    this._statusListeners.clear();
+  }
+
+  private _computeStatus(): ProviderStatus {
+    if (!this.subscription) return "disconnected";
+    if (!this._connected) return "connecting";
+    return this.session.synced ? "synced" : "connected";
+  }
+
+  private _refreshStatus(): void {
+    const next = this._computeStatus();
+    if (next === this._status) return;
+    this._status = next;
+    for (const listener of this._statusListeners) listener({ status: next });
+  }
+
+  // Best-effort presence removal when the tab/page goes away (close, navigation,
+  // bfcache). `pagehide` fires while the socket is still live and is bfcache-safe
+  // (unlike `beforeunload`, which can block it). Sends are not guaranteed to
+  // flush on unload, so the server-side awareness timeout remains the backstop.
+  private _installUnloadHandler(): void {
+    if (typeof window === "undefined" || this._onUnload) return;
+    this._onUnload = () => this.session.removeLocalAwareness();
+    window.addEventListener("pagehide", this._onUnload);
+  }
+
+  private _removeUnloadHandler(): void {
+    if (typeof window === "undefined" || !this._onUnload) return;
+    window.removeEventListener("pagehide", this._onUnload);
+    this._onUnload = null;
   }
 
   // Send one raw protocol frame over the cable. Awareness frames are whispered

--- a/packages/yrb-lite-client/src/index.ts
+++ b/packages/yrb-lite-client/src/index.ts
@@ -10,7 +10,13 @@ export type { YProtocolSessionOptions, SendOptions } from "./y_protocol_session.
 // Ready-made ActionCable / AnyCable provider built on YProtocolSession (with awareness
 // whisper support). Bring your own provider instead by composing YProtocolSession.
 export { ActionCableProvider } from "./actioncable_provider.js";
-export type { ActionCableProviderOptions, CableConsumer, CableSubscription } from "./actioncable_provider.js";
+export type {
+  ActionCableProviderOptions,
+  ProviderStatus,
+  StatusEvent,
+  CableConsumer,
+  CableSubscription,
+} from "./actioncable_provider.js";
 
 // Optional base64 helpers for transports that carry frames as strings.
 export { toBase64, fromBase64 } from "./base64.js";

--- a/packages/yrb-lite-client/src/y_protocol_session.ts
+++ b/packages/yrb-lite-client/src/y_protocol_session.ts
@@ -160,6 +160,18 @@ export class YProtocolSession {
     }
   }
 
+  /**
+   * Broadcast that our local presence is gone (sets local state to null, which
+   * emits a removal awareness frame through `send`). Call this while the
+   * transport is still live so peers drop our cursor immediately instead of
+   * waiting for the awareness timeout. A no-op when there's no local state.
+   */
+  removeLocalAwareness(): void {
+    if (this.awareness && this.awareness.getLocalState() !== null) {
+      this.awareness.setLocalState(null); // fires "update" -> sends the removal frame
+    }
+  }
+
   /** A reliable-delivery `{ ack: id }` envelope arrived. */
   ack(id: number): void {
     this._delivery.onAck(id);

--- a/packages/yrb-lite-client/test/actioncable_provider.test.js
+++ b/packages/yrb-lite-client/test/actioncable_provider.test.js
@@ -1,17 +1,19 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import * as Y from "yjs";
+import * as encoding from "lib0/encoding";
 import { Awareness } from "y-protocols/awareness";
-import { ActionCableProvider, MessageType, fromBase64 } from "../dist/index.js";
+import { ActionCableProvider, MessageType, fromBase64, toBase64 } from "../dist/index.js";
 
 // A fake ActionCable/AnyCable consumer. `withWhisper` toggles AnyCable's
 // client-to-client whisper method so we can test both routing paths.
 function fakeConsumer({ withWhisper } = { withWhisper: false }) {
-  const calls = { send: [], whisper: [] };
+  const calls = { send: [], whisper: [], removed: 0 };
   let sub = null;
   const consumer = {
     calls,
     deliverConnected: () => sub.connected(),
+    deliverDisconnected: () => sub.disconnected(),
     deliverReceived: (msg) => sub.received(msg),
     subscriptions: {
       create(params, mixin) {
@@ -24,13 +26,25 @@ function fakeConsumer({ withWhisper } = { withWhisper: false }) {
         if (withWhisper) sub.whisper = (data) => calls.whisper.push(data);
         return sub;
       },
-      remove: () => {},
+      remove: () => {
+        calls.removed += 1;
+      },
     },
   };
   return consumer;
 }
 
 const frameTypeOf = (b64) => fromBase64(b64)[0];
+
+// Build the envelope a server sends to say "you're caught up": a Sync frame
+// carrying SyncStep2 (message type 1) with the peer's full state.
+function syncStep2Envelope(peerDoc) {
+  const e = encoding.createEncoder();
+  encoding.writeVarUint(e, MessageType.Sync);
+  encoding.writeVarUint(e, 1); // messageYjsSyncStep2
+  encoding.writeVarUint8Array(e, Y.encodeStateAsUpdate(peerDoc));
+  return { update: toBase64(encoding.toUint8Array(e)) };
+}
 
 // Create a provider and register failure-proof cleanup (a fresh Awareness starts
 // its own reaper interval, which would keep the event loop alive otherwise).
@@ -107,4 +121,132 @@ test("reliable doc updates carry an id; an ack drains the queue", (t) => {
   assert.equal(p.hasPending, true);
   c.deliverReceived({ ack: docMsg.id });
   assert.equal(p.hasPending, false, "the ack drained the pending queue");
+});
+
+test("status walks connecting -> connected -> synced -> disconnected", (t) => {
+  const doc = new Y.Doc();
+  const c = fakeConsumer();
+  const p = makeProvider(t, doc, c, { id: "s1" });
+  const seen = [];
+  p.on("status", ({ status }) => seen.push(status));
+
+  assert.equal(p.status, "disconnected", "starts disconnected");
+  p.connect();
+  assert.equal(p.status, "connecting", "subscription created, transport not up");
+  c.deliverConnected();
+  assert.equal(p.status, "connected", "transport up, not yet synced (UI: syncing)");
+  c.deliverReceived(syncStep2Envelope(new Y.Doc()));
+  assert.equal(p.status, "synced", "a SyncStep2 flips us to synced");
+  p.disconnect();
+  assert.equal(p.status, "disconnected", "explicit disconnect -> disconnected");
+
+  assert.deepEqual(seen, ["connecting", "connected", "synced", "disconnected"]);
+});
+
+test("a dropped transport (ActionCable will retry) shows as connecting, not disconnected", (t) => {
+  const c = fakeConsumer();
+  const p = makeProvider(t, new Y.Doc(), c, { id: "s2" });
+  p.connect();
+  c.deliverConnected();
+  assert.equal(p.status, "connected");
+  c.deliverDisconnected(); // transport blip; subscription still alive
+  assert.equal(p.status, "connecting", "subscription still set -> retrying, not torn down");
+});
+
+test("off() removes a status listener", (t) => {
+  const c = fakeConsumer();
+  const p = makeProvider(t, new Y.Doc(), c, { id: "s3" });
+  const seen = [];
+  const listener = ({ status }) => seen.push(status);
+  p.on("status", listener);
+  p.connect();
+  p.off("status", listener);
+  c.deliverConnected();
+  assert.deepEqual(seen, ["connecting"], "no events after off()");
+});
+
+test("disconnect() broadcasts a presence removal while the transport is still live", async (t) => {
+  const doc = new Y.Doc();
+  const c = fakeConsumer({ withWhisper: true });
+  const p = makeProvider(t, doc, c, { id: "d1" });
+  p.connect();
+  c.deliverConnected();
+  p.awareness.setLocalStateField("user", "alice");
+  const whispersBefore = c.calls.whisper.length;
+  assert.notEqual(p.awareness.getLocalState(), null, "alice has presence");
+
+  p.disconnect();
+
+  const removalFrames = c.calls.whisper
+    .slice(whispersBefore)
+    .filter((m) => frameTypeOf(m.update) === MessageType.Awareness);
+  assert.ok(removalFrames.length >= 1, "a final awareness frame went out on disconnect");
+  assert.equal(p.awareness.getLocalState(), null, "local presence cleared");
+
+  // The actual unsubscribe is deferred one microtask so the removal flushes first.
+  assert.equal(c.calls.removed, 0, "unsubscribe is deferred, not synchronous");
+  await Promise.resolve();
+  assert.equal(c.calls.removed, 1, "unsubscribe runs after the microtask");
+});
+
+test("destroy() tears down the Awareness it created, but not a caller-supplied one", () => {
+  // owns: default Awareness -> destroyed on destroy()
+  const owned = new ActionCableProvider(new Y.Doc(), fakeConsumer(), "DocumentChannel", { id: "o1" });
+  let ownedDestroyed = 0;
+  const origDestroy = owned.awareness.destroy.bind(owned.awareness);
+  owned.awareness.destroy = () => {
+    ownedDestroyed += 1;
+    origDestroy();
+  };
+  owned.destroy();
+  assert.equal(ownedDestroyed, 1, "a provider-created Awareness is destroyed");
+
+  // borrowed: caller-supplied Awareness -> left alone
+  const doc = new Y.Doc();
+  const mine = new Awareness(doc);
+  let mineDestroyed = 0;
+  const origMine = mine.destroy.bind(mine);
+  mine.destroy = () => {
+    mineDestroyed += 1;
+    origMine();
+  };
+  const borrowed = new ActionCableProvider(doc, fakeConsumer(), "DocumentChannel", { id: "o2" }, { awareness: mine });
+  borrowed.destroy();
+  assert.equal(mineDestroyed, 0, "a caller-supplied Awareness is left for the caller to own");
+  mine.destroy(); // cleanup the reaper interval
+});
+
+test("a browser pagehide broadcasts a best-effort presence removal", (t) => {
+  // Simulate a browser environment with a minimal window event target.
+  const handlers = new Map();
+  const fakeWindow = {
+    addEventListener: (type, fn) => handlers.set(type, fn),
+    removeEventListener: (type, fn) => {
+      if (handlers.get(type) === fn) handlers.delete(type);
+    },
+  };
+  const prev = globalThis.window;
+  globalThis.window = fakeWindow;
+  t.after(() => {
+    if (prev === undefined) delete globalThis.window;
+    else globalThis.window = prev;
+  });
+
+  const doc = new Y.Doc();
+  const c = fakeConsumer({ withWhisper: true });
+  const p = makeProvider(t, doc, c, { id: "u1" });
+  p.connect();
+  c.deliverConnected();
+  p.awareness.setLocalStateField("user", "carol");
+  assert.ok(handlers.has("pagehide"), "connect() registered a pagehide handler");
+
+  const whispersBefore = c.calls.whisper.length;
+  handlers.get("pagehide")(); // fire pagehide
+  const removal = c.calls.whisper
+    .slice(whispersBefore)
+    .filter((m) => frameTypeOf(m.update) === MessageType.Awareness);
+  assert.ok(removal.length >= 1, "pagehide sent a presence removal");
+
+  p.disconnect();
+  assert.ok(!handlers.has("pagehide"), "disconnect() unregistered the pagehide handler");
 });


### PR DESCRIPTION
Second of the upstream-into-the-client series. Makes `ActionCableProvider` a thin app adapter by absorbing the lifecycle bits every consumer otherwise re-implements — kept **deliberately minimal** per review (no `autoConnect`, no ownership flags, no extra lifecycle callbacks, no separate `sync`/`error` events; expand later if asked).

> Stacked on #19 — base is `client-defensive-receive`. Merge #19 first; GitHub retargets this to `main` automatically.

## Connection status
- `provider.on('status', ({status}) => …)` / `off()`, plus a `status` getter
- One signal: `'connecting' | 'connected'`(syncing)` | 'synced' | 'disconnected'` — no separate sync event
- Driven by the cable's real `connected()`/`disconnected()`, **not** `subscription != null`. A dropped-but-retrying transport reads as `'connecting'`; an explicit teardown as `'disconnected'`.

## Awareness teardown (implicit)
- `disconnect()`/`destroy()` broadcast a presence removal (`setLocalState(null)`) **while the transport is still live**, so peers drop your cursor immediately instead of waiting for the awareness timeout.
- A transient transport blip does **not** clear local presence (it re-announces on reconnect); only an explicit teardown does. The two paths are distinct (cable callback vs. provider method).
- `destroy()` stays **synchronous**; the unsubscribe is deferred one microtask so the removal flushes first. It tears down the `Awareness` **only if the provider created it** (a caller-supplied one is left alone), which also stops its reaper timer.
- Browser `pagehide` sends a best-effort removal (bfcache-safe vs `beforeunload`); the server-side awareness timeout remains the backstop.

`session.removeLocalAwareness()` is the small primitive behind all three paths.

## Held to the critical properties
- **Authoritative / no-leak:** unchanged — doc updates still go server-first via `send`; only ephemeral awareness is whispered. No peer-to-peer doc path added.
- **Reliability/durability:** reliable delivery untouched; status is read-only observability.
- **Perf:** no global `beforeunload`; `pagehide` only; reaper timer stopped on owned-Awareness teardown.

## Tests (32/32)
status walk, retry-vs-teardown distinction, `off()`, presence removal + deferred unsubscribe, created-vs-borrowed Awareness ownership, and a simulated `pagehide`.

Next: (4) collapse lexxy to a thin adapter on these hooks + re-run the browser e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)