### PR TITLE
Client hardening from the audit (#1/#5/#7/#9/#10)

### DIFF
--- a/packages/yrb-lite-client/src/actioncable_provider.ts
+++ b/packages/yrb-lite-client/src/actioncable_provider.ts
@@ -60,7 +60,11 @@ export interface ActionCableProviderOptions
     YProtocolSessionOptions,
     "reliable" | "resendInterval" | "maxUnconfirmedResends" | "onFallback" | "onError"
   > {
-  /** Awareness/presence instance. Defaults to a fresh `new Awareness(doc)`. */
+  /**
+   * Awareness/presence instance. Omit (`undefined`) for a fresh
+   * `new Awareness(doc)` the provider owns; pass `null` to disable awareness
+   * entirely; pass your own to share one you manage.
+   */
   awareness?: Awareness | null;
 }
 
@@ -75,7 +79,7 @@ export class ActionCableProvider {
   readonly consumer: CableConsumer;
   readonly channelName: string;
   readonly channelParams: object;
-  readonly awareness: Awareness;
+  readonly awareness: Awareness | null;
   readonly session: YProtocolSession;
   private subscription: CableSubscription | null = null;
   private _onError: (error: unknown, context: string) => void;
@@ -96,8 +100,9 @@ export class ActionCableProvider {
     this.consumer = consumer;
     this.channelName = channelName;
     this.channelParams = channelParams;
-    this._ownsAwareness = opts.awareness == null;
-    this.awareness = opts.awareness ?? new Awareness(doc);
+    // undefined -> create one we own; null -> awareness disabled; value -> borrowed.
+    this._ownsAwareness = opts.awareness === undefined;
+    this.awareness = opts.awareness === undefined ? new Awareness(doc) : opts.awareness;
     this._onError = opts.onError ?? ((error, context) => console.warn(`[yrb-lite] ${context}:`, error));
 
     this.session = new YProtocolSession(doc, {
@@ -201,7 +206,7 @@ export class ActionCableProvider {
     this.session.destroy();
     // Only tear down the Awareness if we created it; a caller-supplied one is
     // theirs to own (and destroying it stops its reaper timer either way).
-    if (this._ownsAwareness) this.awareness.destroy();
+    if (this._ownsAwareness && this.awareness) this.awareness.destroy();
     this._statusListeners.clear();
   }
 

--- a/packages/yrb-lite-client/src/reliable_sync.ts
+++ b/packages/yrb-lite-client/src/reliable_sync.ts
@@ -70,6 +70,9 @@ export class ReliableSync {
   private _resendsSinceProgress = 0;
   private _connected = false;
   private _timer: TimerHandle | undefined = undefined;
+  // Memoized merge of the unacked tail. The tail only changes on enqueue/ack, so
+  // retransmit ticks reuse this instead of re-merging the whole queue each time.
+  private _tailCache: Uint8Array | undefined = undefined;
 
   constructor(opts: ReliableSyncOptions) {
     const { send, merge, resendInterval, maxUnconfirmedResends, onFallback } = opts ?? ({} as ReliableSyncOptions);
@@ -101,6 +104,7 @@ export class ReliableSync {
       return;
     }
     this.pending.push({ seq: this.nextSeq++, update });
+    this._tailCache = undefined; // tail changed
     this.flush();
   }
 
@@ -111,17 +115,22 @@ export class ReliableSync {
    */
   flush(): void {
     if (!this._connected || this.pending.length === 0) return;
-    const updates = this.pending.map((p) => p.update);
-    const merged = updates.length === 1 ? updates[0] : this._merge(updates);
-    const id = this.pending[this.pending.length - 1].seq;
-    this._send(merged, id);
+    this._send(this._mergedTail(), this.pending[this.pending.length - 1].seq);
   }
 
-  /** Confirm delivery up to `id`: prune every queued update with seq <= id. */
+  /**
+   * Confirm delivery up to `id`: prune every queued update with seq <= id.
+   * Acks arrive over the wire, so validate before pruning -- a malformed value
+   * (NaN/string/negative) or an impossible future id must not silently drop the
+   * queue. Invalid acks are ignored.
+   */
   onAck(id: number): void {
+    if (!Number.isSafeInteger(id) || id < 0) return; // malformed / impossible
+    if (this.pending.length > 0 && id > this.pending[this.pending.length - 1].seq) return; // future ack
     this.everAcked = true;
     this._resendsSinceProgress = 0;
     this.pending = this.pending.filter((p) => p.seq > id);
+    this._tailCache = undefined; // tail changed
   }
 
   /** Transport (re)connected: replay the unacked tail and resume retransmits. */
@@ -146,10 +155,7 @@ export class ReliableSync {
   onTick(): void {
     if (!this._connected || this.pending.length === 0) return;
     if (!this.everAcked && ++this._resendsSinceProgress > this.maxUnconfirmedResends) {
-      this.reliable = false;
-      this.pending = [];
-      this._stopTimer();
-      this._onFallback?.();
+      this._fallback();
       return;
     }
     this.flush();
@@ -159,6 +165,31 @@ export class ReliableSync {
   destroy(): void {
     this._stopTimer();
     this.pending = [];
+    this._tailCache = undefined;
+  }
+
+  /** The unacked tail merged into one delta (memoized between tail changes). */
+  private _mergedTail(): Uint8Array {
+    if (this._tailCache === undefined) {
+      const updates = this.pending.map((p) => p.update);
+      this._tailCache = updates.length === 1 ? updates[0] : this._merge(updates);
+    }
+    return this._tailCache;
+  }
+
+  /**
+   * The server never acked after maxUnconfirmedResends: assume it doesn't support
+   * reliable delivery and switch to fire-and-forget. Deliver the tail one last
+   * time first so an edit isn't lost just because no ack ever came -- THEN drop
+   * retention (idempotent CRDT sync covers anything that still slips).
+   */
+  private _fallback(): void {
+    this.reliable = false;
+    if (this.pending.length > 0) this._send(this._mergedTail(), undefined);
+    this.pending = [];
+    this._tailCache = undefined;
+    this._stopTimer();
+    this._onFallback?.();
   }
 
   private _startTimer(): void {

--- a/packages/yrb-lite-client/src/y_protocol_session.ts
+++ b/packages/yrb-lite-client/src/y_protocol_session.ts
@@ -123,7 +123,12 @@ export class YProtocolSession {
     this.doc.on("update", this._onDocUpdate);
 
     if (this.awareness) {
-      this._onAwarenessUpdate = ({ added, updated, removed }: AwarenessChange) => {
+      this._onAwarenessUpdate = ({ added, updated, removed }: AwarenessChange, origin: unknown) => {
+        // Only broadcast OUR OWN presence changes (origin "local"). Updates we
+        // applied from a peer -- and our own remote-cleanup in onDisconnect --
+        // carry origin === this; re-sending those would echo presence and
+        // broadcast tombstones for other clients' cursors.
+        if (origin === this) return;
         const changed = added.concat(updated, removed);
         this._send(this._frameAwareness(changed), undefined, { awareness: true }); // fire-and-forget
       };
@@ -198,20 +203,28 @@ export class YProtocolSession {
         }
         case MessageType.Awareness:
           if (this.awareness) applyAwarenessUpdate(this.awareness, decoding.readVarUint8Array(decoder), this);
-          return null;
+          break;
         case MessageType.QueryAwareness:
-          if (!this.awareness) return null;
-          encoding.writeVarUint(encoder, MessageType.Awareness);
-          encoding.writeVarUint8Array(
-            encoder,
-            encodeAwarenessUpdate(this.awareness, [...this.awareness.getStates().keys()])
-          );
+          if (this.awareness) {
+            encoding.writeVarUint(encoder, MessageType.Awareness);
+            encoding.writeVarUint8Array(
+              encoder,
+              encodeAwarenessUpdate(this.awareness, [...this.awareness.getStates().keys()])
+            );
+          }
           break;
         case MessageType.Auth:
           readAuthMessage(decoder, this.doc, (_doc, reason) => console.warn(`[yrb-lite] auth denied: ${reason}`));
-          return null;
+          break;
         default:
           return null; // unknown message type: ignore
+      }
+      // This protocol is one message per frame. Anything left after a complete
+      // message is malformed (trailing garbage, or low-level packed messages
+      // whose tail we'd silently drop) -- reject it rather than partially trust.
+      if (decoding.hasContent(decoder)) {
+        this._onError(new Error("frame has trailing bytes after a complete message"), "receive");
+        return null;
       }
       return encoding.length(encoder) > 1 ? encoding.toUint8Array(encoder) : null;
     } catch (error) {

--- a/packages/yrb-lite-client/test/actioncable_provider.test.js
+++ b/packages/yrb-lite-client/test/actioncable_provider.test.js
@@ -216,6 +216,23 @@ test("destroy() tears down the Awareness it created, but not a caller-supplied o
   mine.destroy(); // cleanup the reaper interval
 });
 
+test("awareness: null disables it; undefined creates an owned one", (t) => {
+  const c = fakeConsumer({ withWhisper: true });
+  const disabled = new ActionCableProvider(new Y.Doc(), c, "DocumentChannel", { id: "a1" }, { awareness: null });
+  assert.equal(disabled.awareness, null, "null disables awareness");
+  disabled.connect();
+  c.deliverConnected();
+  disabled.disconnect(); // no presence removal possible
+  const anyAwareness = [...c.calls.send, ...c.calls.whisper].some(
+    (m) => frameTypeOf(m.update) === MessageType.Awareness
+  );
+  assert.equal(anyAwareness, false, "no awareness traffic at all when disabled");
+  disabled.destroy(); // must not throw on a null awareness
+
+  const owned = makeProvider(t, new Y.Doc(), fakeConsumer(), { id: "a2" });
+  assert.ok(owned.awareness instanceof Awareness, "undefined creates an owned Awareness");
+});
+
 test("a browser pagehide broadcasts a best-effort presence removal", (t) => {
   // Simulate a browser environment with a minimal window event target.
   const handlers = new Map();

--- a/packages/yrb-lite-client/test/reliable_sync.test.js
+++ b/packages/yrb-lite-client/test/reliable_sync.test.js
@@ -130,3 +130,51 @@ test("an ack resets the fallback counter (slow but live link doesn't fall back)"
   for (let i = 0; i < 2; i++) h.tick();
   assert.equal(h.rs.reliable, true, "acks keep the connection out of fallback");
 });
+
+test("fallback delivers the tail one last time before dropping retention", () => {
+  const h = harness({ maxUnconfirmedResends: 2 });
+  h.rs.onConnect();
+  h.rs.enqueue(u(1));
+  h.rs.enqueue(u(2));
+  const before = h.sent.length;
+  for (let i = 0; i < 3; i++) h.tick(); // trip the fallback
+
+  assert.equal(h.rs.reliable, false, "fell back");
+  const afterFallback = h.sent.slice(before);
+  assert.ok(afterFallback.length >= 1, "the tail was flushed during fallback");
+  const last = h.sent.at(-1);
+  assert.equal(last.id, undefined, "the final delivery is fire-and-forget (no id)");
+  assert.equal(h.rs.hasPending, false, "retention dropped after the final flush");
+});
+
+test("onAck ignores malformed, negative, and impossible future acks", () => {
+  const h = harness();
+  h.rs.onConnect();
+  h.rs.enqueue(u(1));
+  h.rs.enqueue(u(2)); // seqs 1,2
+
+  h.rs.onAck(NaN);
+  h.rs.onAck("2"); // not a number at runtime
+  h.rs.onAck(-1);
+  h.rs.onAck(999); // future: beyond the highest pending seq
+  assert.equal(h.rs.hasPending, true, "no invalid ack pruned the queue");
+  assert.equal(h.rs.pending.length, 2);
+
+  h.rs.onAck(1); // valid
+  assert.equal(h.rs.pending.length, 1, "a valid ack prunes seq <= id");
+});
+
+test("the merged tail is memoized across retransmit ticks, invalidated on change", () => {
+  const h = harness();
+  h.rs.onConnect();
+  h.rs.enqueue(u(1));
+  h.rs.enqueue(u(2)); // one merge for this flush
+  const mergesAfterFlush = h.mergeCalls.length;
+
+  h.tick();
+  h.tick();
+  assert.equal(h.mergeCalls.length, mergesAfterFlush, "retransmits reuse the memoized tail");
+
+  h.rs.enqueue(u(3)); // tail changed -> next flush re-merges
+  assert.equal(h.mergeCalls.length, mergesAfterFlush + 1, "enqueue invalidates the cache");
+});

--- a/packages/yrb-lite-client/test/y_protocol_session.test.js
+++ b/packages/yrb-lite-client/test/y_protocol_session.test.js
@@ -239,3 +239,47 @@ test("receive: an unknown message type is ignored without error", () => {
   assert.equal(errors.length, 0, "unknown type is not an error, just ignored");
   eng.destroy();
 });
+
+test("receive: trailing bytes after a complete message are rejected via onError", () => {
+  const errors = [];
+  const doc = new Y.Doc();
+  const eng = new YProtocolSession(doc, { ...noTimers, send: () => {}, onError: (_e, c) => errors.push(c) });
+  const good = syncStep1Frame(new Y.Doc());
+  const padded = new Uint8Array(good.length + 1);
+  padded.set(good, 0);
+  padded[good.length] = 0xff; // one extra garbage byte
+  const reply = eng.receive(padded);
+  assert.equal(reply, null, "a frame with trailing bytes yields no reply");
+  assert.ok(errors.includes("receive"), "trailing bytes reported via onError");
+  eng.destroy();
+});
+
+test("awareness: applying a remote update does NOT echo it back out (origin guard)", () => {
+  // A produces a presence frame.
+  const docA = new Y.Doc();
+  const awA = new Awareness(docA);
+  const engA = new YProtocolSession(docA, { awareness: awA, send: () => {} });
+  awA.setLocalStateField("user", "alice");
+  const e = encoding.createEncoder();
+  encoding.writeVarUint(e, MSG.Awareness);
+  encoding.writeVarUint8Array(e, encodeAwarenessUpdate(awA, [docA.clientID]));
+  const aliceFrame = encoding.toUint8Array(e);
+
+  // B applies it and must NOT re-send anything (no echo).
+  const docB = new Y.Doc();
+  const awB = new Awareness(docB);
+  const sentB = [];
+  const engB = new YProtocolSession(docB, { awareness: awB, send: (f) => sentB.push(f) });
+  engB.receive(aliceFrame);
+  assert.equal(awB.getStates().get(docA.clientID)?.user, "alice", "remote presence applied");
+  assert.equal(
+    sentB.filter((f) => frameType(f) === MSG.Awareness).length,
+    0,
+    "applied remote presence is NOT echoed back out"
+  );
+
+  engA.destroy();
+  engB.destroy();
+  awA.destroy();
+  awB.destroy();
+});


### PR DESCRIPTION
Client hardening from the code audit (#1, #5, #7, #9, #10)

Stacked on the status/teardown branch. Addresses the audit's client-side
reliability/security findings:

#1 Reliable delivery + ack validation (reliable_sync.ts):
- onAck now validates: ignores non-safe-integer/negative acks and impossible
  "future" acks beyond the highest pending seq. Previously a malformed ack (e.g.
  a string -> NaN compare) silently pruned the ENTIRE pending queue.
- Fallback no longer just drops the queue: it flushes the unacked tail one last
  time fire-and-forget, THEN clears retention -- so an edit isn't lost just
  because no ack ever arrived. (Better than the audit's literal "never clear",
  which would retain a tail forever with nothing left to prune it.)

#9 Bounded merge work (reliable_sync.ts):
- Memoize the merged unacked tail; retransmit ticks reuse it instead of
  re-merging the whole queue every time. Invalidated on enqueue/ack. (Chose this
  concrete perf win over count/byte caps, which would drop data or add surprising
  behavior; growth under no-ack is already bounded by the fallback.)

#5 Awareness origin guard (y_protocol_session.ts):
- _onAwarenessUpdate now respects the listener's origin and only broadcasts our
  OWN presence (origin "local"). Applied-from-remote updates and our own
  remote-cleanup carry origin === this; re-sending those echoed presence and
  broadcast tombstones for other clients' cursors.

#7 Reject trailing/packed bytes (y_protocol_session.ts):
- receive() now checks decoder exhaustion after a complete message; trailing
  bytes (or low-level packed messages whose tail we'd drop) are rejected and
  reported via onError instead of partially trusted.

#10 Awareness lifecycle (actioncable_provider.ts):
- Distinguish undefined (create an owned Awareness) from null (disable awareness
  entirely). awareness is now Awareness | null.

Tests: ack validation (malformed/future), fallback-then-flush, tail memoization,
origin no-echo, trailing-byte rejection, null-awareness disable. 38/38 pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
