### PR TITLE
Gem hardening from the audit (#3/#8/#12/#14/#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ documents.
 
 ```ruby
 class DocumentChannel < ApplicationCable::Channel
-  include YrbLite::Sync
+  include YrbLite::ActionCable::Sync
 
   def subscribed   = sync_for(params[:id])
   def receive(data) = sync_receive(data)
-  def unsubscribed = sync_clear_presence
+  def unsubscribed = sync_unsubscribed(params[:id])
 end
 ```
 
@@ -45,7 +45,11 @@ welcome.
 ## Install
 
 ```ruby
+# Core CRDT + protocol primitives:
 gem "yrb-lite"
+
+# For the Rails/ActionCable server concern (YrbLite::ActionCable::Sync):
+gem "yrb-lite-actioncable"
 ```
 
 Requires Ruby 3.4 or newer. Precompiled gems ship for Linux and macOS on Ruby
@@ -128,13 +132,14 @@ send_to_peer(response) unless response.empty?
 
 ### ActionCable Integration
 
-`YrbLite::Sync` is a channel concern that implements the full y-websocket
-protocol (document sync + awareness/presence) over ActionCable:
+`YrbLite::ActionCable::Sync` (from the `yrb-lite-actioncable` gem) is a channel
+concern that implements the full y-websocket protocol (document sync +
+awareness/presence) over ActionCable:
 
 ```ruby
 # app/channels/document_channel.rb
 class DocumentChannel < ApplicationCable::Channel
-  include YrbLite::Sync
+  include YrbLite::ActionCable::Sync
 
   # Optional persistence:
   # on_load { |key| Document.find_by(key: key)&.content }
@@ -149,7 +154,7 @@ class DocumentChannel < ApplicationCable::Channel
   end
 
   def unsubscribed
-    sync_clear_presence
+    sync_unsubscribed(params[:id])
   end
 end
 ```
@@ -211,7 +216,7 @@ copy.
 
 ```ruby
 class DocumentChannel < ApplicationCable::Channel
-  include YrbLite::Sync
+  include YrbLite::ActionCable::Sync
   sync_backend :store
 
   on_load  { |key| MyStore.load(key) }          # required: source of truth
@@ -261,7 +266,7 @@ auditing or to guarantee nothing is distributed until it's stored, register an
 
 ```ruby
 class DocumentChannel < ApplicationCable::Channel
-  include YrbLite::Sync
+  include YrbLite::ActionCable::Sync
 
   on_change do |key, update|
     # Synchronous, durable write. `update` is the exact CRDT delta.
@@ -270,7 +275,7 @@ class DocumentChannel < ApplicationCable::Channel
 
   def subscribed = sync_for(params[:id])
   def receive(data) = sync_receive(data)
-  def unsubscribed = sync_clear_presence
+  def unsubscribed = sync_unsubscribed(params[:id])
 end
 ```
 

--- a/lib/yrb_lite/action_cable/sync.rb
+++ b/lib/yrb_lite/action_cable/sync.rb
@@ -52,6 +52,11 @@ module YrbLite::ActionCable # rubocop:disable Style/ClassAndModuleChildren
     MSG_KIND_AWARENESS = 3
     MSG_KIND_AWARENESS_QUERY = 4
 
+    # Default incoming-frame size cap (decoded bytes). Generous enough for a
+    # large initial SyncStep2, small enough to bound a single message's
+    # allocation/parse cost. Override per channel with `max_frame_bytes`.
+    DEFAULT_MAX_FRAME_BYTES = 8 * 1024 * 1024
+
     def self.included(base)
       base.extend(ClassMethods)
     end
@@ -61,14 +66,26 @@ module YrbLite::ActionCable # rubocop:disable Style/ClassAndModuleChildren
       # return a binary Y.js update (or nil for a fresh document).
       def on_load(callable = nil, &block)
         @on_load = callable || block if callable || block
-        @on_load
+        return @on_load if defined?(@on_load) && @on_load
+
+        superclass.respond_to?(:on_load) ? superclass.on_load : nil
       end
 
-      # Persist document state. Called with (key, update) after every
+      # Persist a document *snapshot*. Called with (key, update) after every
       # message that modified the document.
+      #
+      # NOTE: on_save is best-effort snapshotting, not authoritative durability.
+      # It runs outside the per-document apply lock, so against a last-write-wins
+      # store two overlapping saves can race and an older snapshot can land last.
+      # For durable, ordered, accepted-change guarantees use `on_change` (which
+      # records under the lock, before apply/broadcast); pair it with on_save only
+      # as a read-path optimization (a snapshot to load from instead of replaying
+      # the whole change log).
       def on_save(callable = nil, &block)
         @on_save = callable || block if callable || block
-        @on_save
+        return @on_save if defined?(@on_save) && @on_save
+
+        superclass.respond_to?(:on_save) ? superclass.on_save : nil
       end
 
       # Record every document change durably before it is applied or
@@ -90,7 +107,9 @@ module YrbLite::ActionCable # rubocop:disable Style/ClassAndModuleChildren
       # and broadcasts, with an optional on_save snapshot.
       def on_change(callable = nil, &block)
         @on_change = callable || block if callable || block
-        @on_change
+        return @on_change if defined?(@on_change) && @on_change
+
+        superclass.respond_to?(:on_change) ? superclass.on_change : nil
       end
 
       # Select the document backend:
@@ -103,9 +122,28 @@ module YrbLite::ActionCable # rubocop:disable Style/ClassAndModuleChildren
       #     store (`on_load`); changes are recorded (`on_change`) and relayed.
       #     Works under AnyCable (broadcasts handled outside Ruby, no worker
       #     affinity) and across processes. Requires `on_load` and `on_change`.
+      #
+      #     Presence in :store mode is peer-whisper only: the server relays
+      #     awareness but keeps no ephemeral awareness state and answers no
+      #     awareness query, so a late joiner sees other cursors as they next
+      #     move rather than immediately. Document data is fully consistent; only
+      #     presence is best-effort.
       def sync_backend(mode = nil)
         @sync_backend = mode if mode
-        @sync_backend || :memory
+        return @sync_backend if defined?(@sync_backend) && @sync_backend
+
+        superclass.respond_to?(:sync_backend) ? superclass.sync_backend : :memory
+      end
+
+      # Maximum size, in decoded bytes, of an incoming document/awareness frame.
+      # Oversized frames are dropped before base64 decode and before native
+      # parsing, so a client can't force huge allocations/CPU (a DoS vector).
+      # Defaults to DEFAULT_MAX_FRAME_BYTES; set to nil to disable the cap.
+      def max_frame_bytes(bytes = :__unset__)
+        @max_frame_bytes = bytes unless bytes == :__unset__
+        return @max_frame_bytes if defined?(@max_frame_bytes)
+
+        superclass.respond_to?(:max_frame_bytes) ? superclass.max_frame_bytes : DEFAULT_MAX_FRAME_BYTES
       end
     end
 
@@ -161,11 +199,19 @@ module YrbLite::ActionCable # rubocop:disable Style/ClassAndModuleChildren
       # Optional client-supplied id for reliable delivery (see sync_send_ack).
       id = data.is_a?(Hash) ? data["id"] : nil
 
+      # Frame-size cap: drop oversized frames before decoding (the encoded form
+      # is ~4/3 the decoded size) and again after, so a client can't force large
+      # base64 decodes / native parses / merges. A dropped frame is never acked.
+      cap = self.class.max_frame_bytes
+      return if cap && m.bytesize > (cap * 4 / 3) + 4
+
       begin
         bytes = Base64.strict_decode64(m)
       rescue ArgumentError
         return # not valid base64; ignore the frame and keep the connection
       end
+
+      return if cap && bytes.bytesize > cap
 
       sync_send_ack(id, sync_dispatch(m, bytes))
     end
@@ -399,8 +445,26 @@ module YrbLite::ActionCable # rubocop:disable Style/ClassAndModuleChildren
     # outside Ruby) relays them directly. Send the opening SyncStep1 built from
     # the durable store. No warm replica is kept.
     def sync_for_store_backed
+      sync_require_store_recorder!
       sync_stream sync_stream_name
       sync_transmit(sync_load_doc.sync_step1)
+    end
+
+    # Store mode acks updates as *durably recorded*, so it MUST have both a
+    # loader (to rebuild the doc and detect causal gaps) and a recorder (to
+    # actually persist before acking). Fail closed at subscribe time rather than
+    # silently acking and broadcasting updates that were never stored -- which a
+    # cold load or reconnect would then lose.
+    def sync_require_store_recorder!
+      missing = []
+      missing << :on_load unless self.class.on_load
+      missing << :on_change unless self.class.on_change
+      return if missing.empty?
+
+      raise YrbLite::Error,
+            "sync_backend :store requires #{missing.join(" and ")}. Store mode acks " \
+            "updates as durably recorded; without a recorder an ack would claim a " \
+            "persistence that never happened, and a cold load would lose the edit."
     end
 
     # Subscribe to the document's broadcast stream. Under AnyCable (which adds a
@@ -445,9 +509,13 @@ module YrbLite::ActionCable # rubocop:disable Style/ClassAndModuleChildren
           return :gap
         end
 
-        if (recorder = self.class.on_change)
-          sync_record_change(recorder, update) # record before relay
-        end
+        # Defense in depth: sync_require_store_recorder! makes this unreachable
+        # without a recorder, but never broadcast/ack as :recorded if one is
+        # somehow absent -- that would acknowledge an unstored update.
+        recorder = self.class.on_change
+        return :noop unless recorder
+
+        sync_record_change(recorder, update) # record before relay
         sync_distribute(encoded)
         :recorded
       when MSG_KIND_AWARENESS

--- a/test/sync_test.rb
+++ b/test/sync_test.rb
@@ -722,4 +722,70 @@ class SyncTest < Minitest::Test
     assert_equal 0, result[1] # Responding to STEP1
     assert_kind_of String, result[2] # Response bytes (SyncStep2)
   end
+
+  # --- Audit hardening ---------------------------------------------------
+
+  def test_store_backend_fails_closed_without_recorder
+    klass = Class.new do
+      include YrbLite::ActionCable::Sync
+
+      sync_backend :store
+      on_load { |_key| nil }
+      # deliberately no on_change
+    end
+    err = assert_raises(YrbLite::Error) { klass.new.send(:sync_require_store_recorder!) }
+    assert_match(/on_change/, err.message)
+  end
+
+  def test_store_backend_requires_loader_too
+    klass = Class.new do
+      include YrbLite::ActionCable::Sync
+
+      sync_backend :store
+      on_change { |_key, _update| nil }
+      # deliberately no on_load
+    end
+    err = assert_raises(YrbLite::Error) { klass.new.send(:sync_require_store_recorder!) }
+    assert_match(/on_load/, err.message)
+  end
+
+  def test_store_backend_with_both_callbacks_passes
+    klass = Class.new do
+      include YrbLite::ActionCable::Sync
+
+      sync_backend :store
+      on_load { |_key| nil }
+      on_change { |_key, _update| nil }
+    end
+    klass.new.send(:sync_require_store_recorder!) # must not raise
+  end
+
+  def test_config_is_inherited_by_subclasses
+    base = Class.new do
+      include YrbLite::ActionCable::Sync
+
+      sync_backend :store
+      on_load { |_key| nil }
+      on_change { |_key, _update| nil }
+    end
+    sub = Class.new(base)
+
+    assert_equal :store, sub.sync_backend, "sync_backend inherits"
+    refute_nil sub.on_load, "on_load inherits"
+    refute_nil sub.on_change, "on_change inherits"
+  end
+
+  def test_max_frame_bytes_default_override_and_disable
+    klass = Class.new { include YrbLite::ActionCable::Sync }
+
+    assert_equal YrbLite::ActionCable::Sync::DEFAULT_MAX_FRAME_BYTES, klass.max_frame_bytes
+
+    klass.max_frame_bytes 1024
+
+    assert_equal 1024, klass.max_frame_bytes
+
+    klass.max_frame_bytes nil # explicitly disable the cap
+
+    assert_nil klass.max_frame_bytes
+  end
 end

--- a/yrb-lite-actioncable.gemspec
+++ b/yrb-lite-actioncable.gemspec
@@ -34,6 +34,12 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "base64", "~> 0.2"
   spec.add_dependency "yrb-lite", ">= 0.1.0.beta5"
+  # The concern references ActionCable (channels, streaming, broadcasting) and
+  # ActiveSupport (Concern, JSON coder) constants directly. Rails apps already
+  # bundle these, but declaring them makes use outside a full Rails bundle fail
+  # at install time with a clear message instead of at runtime with a NameError.
+  spec.add_dependency "actioncable", ">= 7.0"
+  spec.add_dependency "activesupport", ">= 7.0"
 
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
Gem hardening from the code audit (#3, #8, #12, #14, #15, #4/#13 docs)

#3 Store backend fails closed (was: ack+broadcast unstored updates):
- sync_backend :store now REQUIRES on_load and on_change. sync_for_store_backed
  raises YrbLite::Error at subscribe time if either is missing, and
  sync_receive_store_backed returns :noop (never :recorded) if no recorder is
  present -- so an update is never acked as durable unless it was actually
  recorded. Previously a missing on_change still broadcast and acked :recorded,
  which a cold load/reconnect would then lose.

#8 Frame-size cap (was: README claimed drops, code had none -> DoS vector):
- DEFAULT_MAX_FRAME_BYTES (8 MiB decoded), overridable per channel via
  max_frame_bytes (nil disables). sync_receive drops oversized frames before
  base64 decode (encoded ~4/3 the size) and again after decode, before any
  native parse/merge. A dropped frame is never acked.

#12 Config inheritance (was: class ivars not inherited by subclasses):
- on_load/on_save/on_change/sync_backend/max_frame_bytes now fall back to the
  superclass's value when not set locally, so configuring a base channel and
  subclassing it no longer silently loses callbacks/backend.

#14 Explicit framework deps:
- gemspec now declares actioncable and activesupport (>= 7.0). The concern uses
  their constants directly; declaring them fails at install, not runtime.

#15 Root README refreshed after the package split:
- include YrbLite::Sync -> include YrbLite::ActionCable::Sync
- install snippet adds gem "yrb-lite-actioncable" for the server concern
- unsubscribe examples use sync_unsubscribed(params[:id]) (presence + eviction)

#4 on_save documented as best-effort snapshotting (races the apply lock under
   last-write-wins stores); on_change is the durable path.
#13 store-mode presence documented as peer-whisper only (no server awareness
   state / query); document data is fully consistent.

Tests: store fail-closed (missing recorder/loader), both-present passes, config
inheritance through a subclass, max_frame_bytes default/override/disable.
40 runs, 0 failures; rubocop clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
