### PR TITLE
Exactly-once durable side effects on lost-ack retries (#2)

### DIFF
--- a/ext/yrb_lite/src/lib.rs
+++ b/ext/yrb_lite/src/lib.rs
@@ -240,6 +240,48 @@ fn update_is_ready(doc: &Doc, update_bytes: &[u8]) -> Result<bool, String> {
     Ok(doc.transact().state_vector() >= update.state_vector_lower())
 }
 
+/// True if applying `update_bytes` would actually change `doc` -- i.e. it carries
+/// content the doc doesn't already have. Lets the server make durable side
+/// effects exactly-once: a lost-ack retry re-sends an update the server already
+/// applied; that retry is causally ready (so `update_is_ready` is true) but must
+/// NOT re-run `on_change`.
+///
+/// Inserts are decided exactly via the state vector: if the doc already covers
+/// every (client, clock) the update carries, the update is a duplicate and does
+/// not advance. Deletes do not move the state vector, so we can't cheaply prove a
+/// delete-bearing update is a duplicate -- we conservatively report it as
+/// advancing (record it). That can still double-record a pure-delete retry, but
+/// it NEVER drops a real deletion, which is the safe direction. Assumes the
+/// update is already causally ready (call `update_is_ready` first).
+fn update_advances_doc(doc: &Doc, update_bytes: &[u8]) -> Result<bool, String> {
+    let update = yrs::Update::decode_v1(update_bytes).map_err(|e| e.to_string())?;
+    if !update.delete_set().is_empty() {
+        return Ok(true); // can't cheaply prove a delete is a duplicate; record it
+    }
+    // We can't read the update's own state vector to decide this: yrs reports an
+    // EMPTY state_vector() for a causally-pending diff (e.g. a resync delta whose
+    // structs depend on updates the doc has but the standalone update doesn't),
+    // which would look identical to a no-op. So measure the real effect: seed an
+    // independent probe with the doc's current state, apply the update there, and
+    // see whether the state vector grew. (Deletes don't move the SV, hence the
+    // conservative early-return above.) The probe never touches the live doc.
+    let probe = Doc::new();
+    let current = doc
+        .transact()
+        .encode_state_as_update_v1(&yrs::StateVector::default());
+    probe
+        .transact_mut()
+        .apply_update(yrs::Update::decode_v1(&current).map_err(|e| e.to_string())?)
+        .map_err(|e| e.to_string())?;
+    let before = probe.transact().state_vector();
+    probe
+        .transact_mut()
+        .apply_update(update)
+        .map_err(|e| e.to_string())?;
+    let after = probe.transact().state_vector();
+    Ok(after != before)
+}
+
 /// True if the doc holds pending structs or a pending delete set -- blocks that
 /// couldn't integrate because a dependency is missing. Used as a backstop after
 /// loading from storage: leftover pending means the stored log has a causal gap.
@@ -324,6 +366,15 @@ impl RbDoc {
         let update_bytes = copy_bytes(update);
         let doc = &self.0;
         nogvl(move || update_is_ready(doc, &update_bytes)).map_err(yrb_error)
+    }
+
+    /// True if applying `update` would change the document (it carries new
+    /// content), false if the doc already contains it (an already-applied
+    /// retry). See `update_advances_doc`. Pure read; does not mutate.
+    fn update_advances(&self, update: RString) -> Result<bool, Error> {
+        let update_bytes = copy_bytes(update);
+        let doc = &self.0;
+        nogvl(move || update_advances_doc(doc, &update_bytes)).map_err(yrb_error)
     }
 
     /// True if the document holds pending (un-integrable) structs waiting on a
@@ -610,6 +661,18 @@ impl RbAwareness {
         .map_err(yrb_error)
     }
 
+    /// True if applying `update` would change the document, false if it's an
+    /// already-applied retry. See `update_advances_doc`. Pure read.
+    fn update_advances(&self, update: RString) -> Result<bool, Error> {
+        let update_bytes = copy_bytes(update);
+        let awareness = &self.0;
+        nogvl(move || {
+            let doc = awareness.lock().unwrap().doc().clone();
+            update_advances_doc(&doc, &update_bytes)
+        })
+        .map_err(yrb_error)
+    }
+
     /// True if the document holds pending (un-integrable) structs waiting on a
     /// missing dependency.
     fn pending(&self) -> bool {
@@ -713,6 +776,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     )?;
     doc_class.define_method("apply_update", method!(RbDoc::apply_update, 1))?;
     doc_class.define_method("update_ready?", method!(RbDoc::update_ready, 1))?;
+    doc_class.define_method("update_advances?", method!(RbDoc::update_advances, 1))?;
     doc_class.define_method("pending?", method!(RbDoc::pending, 0))?;
     doc_class.define_method("sync_step1", method!(RbDoc::sync_step1, 0))?;
     doc_class.define_method("sync_step2", method!(RbDoc::sync_step2, 1))?;
@@ -744,6 +808,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     )?;
     awareness_class.define_method("apply_update", method!(RbAwareness::apply_update, 1))?;
     awareness_class.define_method("update_ready?", method!(RbAwareness::update_ready, 1))?;
+    awareness_class.define_method("update_advances?", method!(RbAwareness::update_advances, 1))?;
     awareness_class.define_method("pending?", method!(RbAwareness::pending, 0))?;
     awareness_class.define_method("set_local_state", method!(RbAwareness::set_local_state, 1))?;
     awareness_class.define_method("local_state", method!(RbAwareness::local_state, 0))?;
@@ -838,6 +903,70 @@ mod tests {
 
         let frame = update_frame("hello");
         assert_eq!(classify_message(&frame[..frame.len() / 2]), 0, "truncated");
+    }
+
+    #[test]
+    fn update_advances_is_false_for_an_already_applied_retry() {
+        let doc = Doc::new();
+        let upd = text_update("hello");
+
+        // Against a doc that doesn't have it yet, the update advances.
+        assert!(
+            update_advances_doc(&doc, &upd).unwrap(),
+            "new content advances"
+        );
+
+        // Apply it, then the byte-identical retry no longer advances.
+        doc.transact_mut()
+            .apply_update(yrs::Update::decode_v1(&upd).unwrap())
+            .unwrap();
+        assert!(
+            !update_advances_doc(&doc, &upd).unwrap(),
+            "an already-applied retry does not advance"
+        );
+
+        // A genuinely new insert (from a different client) still advances.
+        let more = text_update("world");
+        assert!(
+            update_advances_doc(&doc, &more).unwrap(),
+            "different new content advances"
+        );
+    }
+
+    #[test]
+    fn update_advances_handles_a_dependent_diff_update() {
+        // A causally-pending diff (its structs depend on content the doc already
+        // has) reports an EMPTY state_vector() in isolation -- a naive check would
+        // misread it as a no-op. Verify the trial-apply gets it right.
+        let doc = Doc::new();
+        let text = doc.get_or_insert_text("content");
+        text.insert(&mut doc.transact_mut(), 0, "a");
+        let a_update = doc
+            .transact()
+            .encode_state_as_update_v1(&yrs::StateVector::default());
+        let sv_a = doc.transact().state_vector();
+        text.insert(&mut doc.transact_mut(), 1, "b");
+        let diff = doc.transact().encode_state_as_update_v1(&sv_a); // depends on "a"
+
+        // A server that has only "a".
+        let server = Doc::new();
+        server
+            .transact_mut()
+            .apply_update(yrs::Update::decode_v1(&a_update).unwrap())
+            .unwrap();
+
+        assert!(
+            update_advances_doc(&server, &diff).unwrap(),
+            "a dependent diff carrying new content advances"
+        );
+        server
+            .transact_mut()
+            .apply_update(yrs::Update::decode_v1(&diff).unwrap())
+            .unwrap();
+        assert!(
+            !update_advances_doc(&server, &diff).unwrap(),
+            "the byte-identical retry of that diff does not advance"
+        );
     }
 
     #[test]

--- a/lib/yrb_lite/action_cable/sync.rb
+++ b/lib/yrb_lite/action_cable/sync.rb
@@ -294,6 +294,13 @@ module YrbLite::ActionCable # rubocop:disable Style/ClassAndModuleChildren
         next :noop unless update
         next :gap unless awareness.update_ready?(update)
 
+        # Exactly-once durable side effects. A lost-ack retry re-sends an update
+        # we already recorded and applied; it's causally ready but doesn't
+        # advance the doc. Ack it (so the client stops retransmitting) WITHOUT
+        # re-recording, re-applying, or re-broadcasting -- otherwise on_change
+        # (audit rows, counters, webhooks, billing) double-fires on every retry.
+        next :applied unless awareness.update_advances?(update)
+
         sync_record_change(recorder, update) # durable write; raise to reject
         awareness.apply_update(update) # only recorded changes reach the doc
         sync_distribute(encoded) # ...and only then the wire
@@ -444,6 +451,12 @@ module YrbLite::ActionCable # rubocop:disable Style/ClassAndModuleChildren
           sync_transmit(doc.sync_step1)
           return :gap
         end
+
+        # Exactly-once: a lost-ack retry re-sends an update already in the store,
+        # so the freshly-loaded doc already contains it and it doesn't advance.
+        # Ack it without recording/relaying again (see update_advances? and the
+        # authoritative path).
+        return :applied unless doc.update_advances?(update)
 
         if (recorder = self.class.on_change)
           sync_record_change(recorder, update) # record before relay

--- a/test/sync_test.rb
+++ b/test/sync_test.rb
@@ -602,7 +602,11 @@ class SyncTest < Minitest::Test
     threads.each(&:join)
 
     refute overlapped, "recorder must never run concurrently for one document"
-    assert_equal 24, log.length, "every change is recorded exactly once"
+    # 24 concurrent deliveries cycle over only 4 DISTINCT updates (frames[i % 4]).
+    # Byte-identical deliveries are the same CRDT change, so each is recorded
+    # exactly once and the duplicates are deduped -- exactly-once side effects,
+    # even under concurrency.
+    assert_equal frames.length, log.length, "each distinct change is recorded exactly once"
 
     # The authoritative document is exactly the in-order replay of the log.
     replay = YrbLite::Doc.new
@@ -721,5 +725,51 @@ class SyncTest < Minitest::Test
     assert_equal 0, result[0] # MSG_SYNC
     assert_equal 0, result[1] # Responding to STEP1
     assert_kind_of String, result[2] # Response bytes (SyncStep2)
+  end
+
+  # --- Exactly-once durable side effects (lost-ack retry) -----------------
+
+  def test_authoritative_retry_acks_without_double_recording
+    key = "exactly-once-room"
+    broadcasts = []
+    recorded = []
+    acks = []
+    helper = authoritative_helper(key, broadcasts: broadcasts) { |_k, u| recorded << u }
+    helper.define_singleton_method(:transmit) { |data| acks << data }
+
+    frame = YrbLite::Awareness.new.encode_update(YjsFixtures::TwoDocsMerged::DOC1_UPDATE)
+    msg = { "m" => Base64.strict_encode64(frame), "id" => 7 }
+
+    helper.sync_receive(msg) # first delivery: record + relay + ack
+    helper.sync_receive(msg) # lost-ack retry: byte-identical
+
+    assert_equal 1, recorded.length, "the retry is NOT recorded again"
+    assert_equal 1, broadcasts.length, "the retry is NOT rebroadcast"
+    assert_equal [{ "ack" => 7 }, { "ack" => 7 }], acks,
+                 "both the original and the retry are acked, so the client stops retransmitting"
+  end
+
+  def test_store_backed_retry_acks_without_double_recording
+    recorded = []
+    broadcasts = []
+    acks = []
+    store = YrbLite::Doc.new
+    loader = ->(_k) { store.encode_state_as_update }
+    recorder = lambda do |_k, update|
+      recorded << update
+      store.apply_update(update) # the "store" now contains the change
+    end
+    helper = store_backed_helper(loader: loader, recorder: recorder, transmits: acks, broadcasts: broadcasts)
+
+    frame = YrbLite::Awareness.new.encode_update(YjsFixtures::TwoDocsMerged::DOC1_UPDATE)
+    msg = { "update" => Base64.strict_encode64(frame), "id" => 5 }
+
+    helper.sync_receive(msg, "doc-key") # record + relay + ack
+    helper.sync_receive(msg, "doc-key") # retry: already in the store
+
+    assert_equal 1, recorded.length, "the retry is NOT recorded again"
+    assert_equal 1, broadcasts.length, "the retry is NOT rebroadcast"
+    assert_equal [{ "ack" => 5 }, { "ack" => 5 }], acks,
+                 "both the original and the retry are acked"
   end
 end


### PR DESCRIPTION
Exactly-once durable side effects on lost-ack retries (#2)

Stacked on the native-cleanup branch (#23). Fixes the audit's #2: a lost-ack
retry re-sends an update the server already recorded+applied. It's causally
ready, so it passed update_ready? and re-ran on_change -- double-firing durable
side effects (audit rows, counters, webhooks, billing) on every retry.

Native: new `update_advances?` on Doc and Awareness.
- "Advances" = applying the update actually changes the doc. We can't read the
  update's own state_vector to decide: yrs reports an EMPTY state_vector() for a
  causally-pending diff (e.g. a resync delta whose structs depend on content the
  doc has), which is indistinguishable from a no-op. So we trial-apply on an
  independent probe seeded with the doc's current state and check whether the
  state vector grew. The probe never touches the live doc.
- Deletes don't move the state vector, so a delete-bearing update is
  conservatively reported as advancing (recorded). That can still double-record a
  rare pure-delete retry, but NEVER drops a real deletion -- the safe direction.
- Cost: O(doc) per UPDATE on the authoritative/store paths (one state encode +
  two applies). The store path already does an O(history) load per update, and
  audit mode is opt-in, so this is acceptable for correctness.

Gem wiring (both authoritative and store-backed paths): after the readiness
gate, `next :applied unless ...update_advances?(update)`. A duplicate is ACKED
(so the client stops retransmitting) but not recorded, applied, or rebroadcast.

Tests:
- Rust: update_advances? false for an already-applied retry; handles a dependent
  diff update (the empty-state_vector trap) correctly; cargo 9/9.
- Ruby: authoritative + store-backed lost-ack retry is acked WITHOUT
  double-recording or rebroadcasting.
- Updated the concurrency total-order test: 24 deliveries over 4 distinct updates
  now record exactly 4 times (exactly-once under concurrency) -- it previously
  asserted 24, which encoded the double-record bug.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
