### PR TITLE
demo: assert audit-log replay-equivalence, not exact entry count

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,13 +173,15 @@ servers:
   causal dependencies are already in the store (checked against `on_load`); a
   causally-incomplete update triggers a resync instead, so the log always
   rebuilds cleanly.
-- **`on_change` is at-least-once.** Every change is recorded durably before it's
-  acked or broadcast (record-before-distribute). A best-effort check skips the
-  common lost-ack retry, but it is **not** cross-process exactly-once: a retry
-  that lands on another process before the first one commits can record the same
-  update twice. **Make `on_change` idempotent** if duplicate side effects would
-  matter (a webhook, a counter) — a raw append-only delta log is naturally fine,
-  since duplicate entries replay idempotently.
+- **`on_change` is at-least-once, and the durable guarantee is that replaying the
+  log reconstructs the document.** Every change is recorded before it's acked or
+  broadcast (record-before-distribute). Entry count is not 1:1 with edits: a
+  best-effort check skips most lost-ack retries but isn't cross-process exact (a
+  retry on another process can record the same update twice), and a resync can
+  coalesce a client's un-acked tail into a single record. So **make `on_change`
+  idempotent** if duplicate side effects would matter (a webhook, a counter) — a
+  raw append-only delta log is naturally fine, since it replays to the same
+  document either way.
 
 There is deliberately no in-gem cross-process lock. One that only spanned a
 single process would give exactly-once at small scale and silently degrade as

--- a/examples/actioncable-demo/frontend/multiprocess.mjs
+++ b/examples/actioncable-demo/frontend/multiprocess.mjs
@@ -14,7 +14,7 @@ import * as awarenessProtocol from "y-protocols/awareness"
 import * as syncProtocol from "y-protocols/sync"
 import * as encoding from "lib0/encoding"
 import * as decoding from "lib0/decoding"
-import { serverText as serverTextRead } from "./server_read.mjs"
+import { serverText as serverTextRead, serverDoc } from "./server_read.mjs"
 
 const PORTS = (process.env.PORTS || "3777,3778").split(",").map(Number)
 const ROOM = `mp-${process.pid}`
@@ -106,8 +106,9 @@ class Client {
 }
 
 const serverText = (port, room = ROOM) => serverTextRead(`http://localhost:${port}`, room)
-const auditCount = async (port) =>
-  (await (await fetch(`http://localhost:${port}/docs/${ROOM}/audit`)).json()).count
+const auditLog = async (port) =>
+  (await fetch(`http://localhost:${port}/docs/${ROOM}/audit`)).json()
+const sameBytes = (a, b) => a.length === b.length && a.every((x, i) => x === b[i])
 
 // --- Scenario ---------------------------------------------------------------
 
@@ -169,11 +170,25 @@ await sleep(600)
 check("presence crosses processes (B sees A's cursor)", b1.presenceNames().includes("ALICE-A"))
 check("presence crosses processes (A sees B's cursor)", a2.presenceNames().includes("BOB-B"))
 
-// 5. One shared audit log: every change recorded exactly once (not per process).
-const countA = await auditCount(portA)
-const countB = await auditCount(portB)
-check(`shared audit log has every change once (${countA} == ${EDITS * 4})`, countA === EDITS * 4)
-check("both processes see the same shared audit log", countA === countB)
+// 5. One shared audit log, complete on its own. Delivery is at-least-once and a
+// resync can coalesce a client's un-acked tail into one record, so entry count
+// isn't 1:1 with edits. What must hold: both processes see the same shared log,
+// and replaying it alone reconstructs the converged document byte-for-byte.
+const auditA = await auditLog(portA)
+const auditB = await auditLog(portB)
+check(
+  "both processes see the same shared audit log",
+  auditA.updates.length === auditB.updates.length &&
+    auditA.updates.every((u, i) => u === auditB.updates[i])
+)
+
+const replay = new Y.Doc()
+for (const entry of auditA.updates) Y.applyUpdate(replay, fromB64(entry))
+const { doc: live } = await serverDoc(`http://localhost:${portA}`, ROOM)
+check(
+  "the shared audit log alone replays to the converged document",
+  sameBytes(Y.encodeStateAsUpdate(replay), Y.encodeStateAsUpdate(live))
+)
 
 clients.forEach((c) => c.ws.close())
 late.ws.close()


### PR DESCRIPTION
Follow-up to #29. The cross-process e2e (`multiprocess.mjs`) asserted the shared audit log held exactly one entry per edit. At-least-once delivery doesn't guarantee that: a resync coalesces a client's un-acked tail into one record (and a lost-ack retry can duplicate one), so entry count isn't 1:1 with edits — the prior pass was a single-process/lock artifact.

Replaces it with the real, scale-independent guarantee (the proven `audit.mjs` pattern):
1. both processes return byte-identical audit logs (cross-process agreement), and
2. replaying that log alone reconstructs the live document byte-for-byte (content-completeness).

README "Delivery guarantees" updated: entries aren't 1:1 with edits; the durable guarantee is replay-completeness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011K7FAbuFfwTZskdFLKVG2E