### PR TITLE
Add yrb-lite-decoder: pure-Ruby decoder + native Doc readers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,3 +65,4 @@ Naming/FileName:
   Exclude:
     - "lib/yrb-lite.rb"
     - "lib/yrb-lite-actioncable.rb"
+    - "lib/yrb-lite-decoder.rb"

--- a/CHANGELOG-decoder.md
+++ b/CHANGELOG-decoder.md
@@ -1,0 +1,25 @@
+# Changelog — yrb-lite-decoder
+
+All notable changes to the `yrb-lite-decoder` gem.
+
+## [Unreleased]
+
+### Added
+- Initial scaffold. `YrbLite::Decoder` reconstructs plain text from a stored Yjs
+  CRDT state **in pure Ruby**, in-process, on the core gem's native extension —
+  no Node, no subprocess, no binary:
+  - `text` — plain text (Lexical `Y.XmlText`, plain `Y.Text`, ProseMirror
+    `Y.XmlFragment`), for search indexing and exports.
+  - `preview` — a compact, truncated single-line preview for list UIs.
+- Block boundaries are preserved as newlines across all three editors, so
+  adjacent paragraphs don't merge into one run of words (which would break word
+  boundaries for search). Verified against real Lexical, ProseMirror/TipTap, and
+  plain-text fixtures in `test/decoder_test.rb`.
+- Requires the core `Doc` content readers (`root_names`, `read_text`, `read_xml`,
+  `read_map`); `read_xml` joins a root's top-level blocks with newlines, and
+  `read_map` serializes a `Y.Map` root to a JSON object string (sorted keys,
+  recursive values) — for reading structured shared state server-side.
+
+Full-fidelity Lexical reconstruction (EditorState JSON / HTML) is intentionally
+**not** in this gem; it's the separate, opt-in `yrb-lite-decode` Bun binary (see
+`packages/yrb-lite-decode`).

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gemspec name: "yrb-lite"
 gemspec name: "yrb-lite-actioncable"
+gemspec name: "yrb-lite-decoder"
 
 gem "rake-compiler"
 gem "rb_sys"

--- a/ext/yrb_lite/src/lib.rs
+++ b/ext/yrb_lite/src/lib.rs
@@ -4,9 +4,10 @@ use magnus::{
 use yrs::sync::{Message, SyncMessage};
 use yrs::updates::decoder::Decode;
 use yrs::updates::encoder::Encode;
-use yrs::{Doc, ReadTxn, Transact};
+use yrs::{Doc, GetString, ReadTxn, Transact};
 
 mod protocol;
+mod read;
 use protocol::{classify_message, merged_doc_update, update_advances_doc, update_is_ready};
 
 /// Wrapper around yrs Doc.
@@ -139,6 +140,52 @@ impl RbDoc {
             txn.state_vector().encode_v1()
         });
         binary_string(&sv)
+    }
+
+    /// Names of the document's root types, so a content reader can find the one
+    /// holding text without knowing it up front.
+    fn root_names(&self) -> Vec<String> {
+        let doc = &self.0;
+        nogvl(move || {
+            doc.transact()
+                .root_refs()
+                .map(|(name, _)| name.to_string())
+                .collect()
+        })
+    }
+
+    fn read_text(&self, name: String) -> Option<String> {
+        let doc = &self.0;
+        nogvl(move || {
+            doc.transact()
+                .get_text(name.as_str())
+                .map(|t| t.get_string(&doc.transact()))
+        })
+    }
+
+    /// Text of an XML-shaped root, one top-level block per line. The walk +
+    /// block-join logic lives in `read::xml_blocks_text` (pure, Rust-tested);
+    /// this just opens the transaction and resolves the root.
+    fn read_xml(&self, name: String) -> Option<String> {
+        let doc = &self.0;
+        nogvl(move || {
+            let txn = doc.transact();
+            let fragment = txn.get_xml_fragment(name.as_str())?;
+            Some(read::xml_blocks_text(&txn, &fragment))
+        })
+    }
+
+    /// A `Y.Map` root serialized to a JSON object string (keys sorted; values
+    /// recursive). Complements read_text/read_xml for structured shared state.
+    /// Callers parse the JSON (e.g. `JSON.parse(doc.read_map("state"))`). The
+    /// serialization lives in `read::map_json` (pure, Rust-tested).
+    fn read_map(&self, name: String) -> Option<String> {
+        let doc = &self.0;
+        nogvl(move || {
+            let txn = doc.transact();
+            let map = txn.get_map(name.as_str())?;
+            Some(read::map_json(&txn, &map))
+        })
     }
 
     /// Encode state as update (optionally diffed against a state vector)
@@ -315,6 +362,10 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
         method!(RbDoc::encode_state_as_update, -1),
     )?;
     doc_class.define_method("apply_update", method!(RbDoc::apply_update, 1))?;
+    doc_class.define_method("root_names", method!(RbDoc::root_names, 0))?;
+    doc_class.define_method("read_text", method!(RbDoc::read_text, 1))?;
+    doc_class.define_method("read_xml", method!(RbDoc::read_xml, 1))?;
+    doc_class.define_method("read_map", method!(RbDoc::read_map, 1))?;
     doc_class.define_method("update_ready?", method!(RbDoc::update_ready, 1))?;
     doc_class.define_method("update_advances?", method!(RbDoc::update_advances, 1))?;
     doc_class.define_method("sync_step1", method!(RbDoc::sync_step1, 0))?;

--- a/ext/yrb_lite/src/read.rs
+++ b/ext/yrb_lite/src/read.rs
@@ -1,0 +1,188 @@
+//! Pure content-reading helpers over yrs shared types — no magnus/Ruby, so they
+//! can be unit-tested directly in Rust (like `protocol.rs`). The binding layer in
+//! `lib.rs` is a thin wrapper that opens a transaction and calls these.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use yrs::{Any, Array, GetString, Map, MapRef, Out, ReadTxn, XmlFragment, XmlFragmentRef, XmlOut};
+
+/// Read an XML-shaped root as text, one top-level block per line.
+///
+/// ProseMirror stores blocks as `Y.XmlElement` children (`<paragraph>…`);
+/// Lexical stores each block as a sibling `Y.XmlText` (its node metadata is an
+/// embed, which yrs omits from the string). We serialize each top-level child and
+/// join with "\n", so adjacent blocks don't merge into one run of words. Without
+/// the separator, Lexical — whose blocks carry no element tags — would glue
+/// paragraphs together (e.g. "first paragraphsecond paragraph"), breaking word
+/// boundaries for search/preview. Element tags are kept (the caller strips them);
+/// deeper nesting is flattened, but its inner tags still separate words after
+/// stripping.
+pub fn xml_blocks_text<T: ReadTxn>(txn: &T, fragment: &XmlFragmentRef) -> String {
+    fragment
+        .children(txn)
+        .map(|node| match node {
+            XmlOut::Element(e) => e.get_string(txn),
+            XmlOut::Text(t) => t.get_string(txn),
+            XmlOut::Fragment(f) => f.get_string(txn),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Read a `Y.Map` root as a JSON object string (keys sorted for stable output).
+///
+/// The complement to `read_text`/`read_xml` for structured state — e.g. a shared
+/// "view state" map. Values are converted recursively: primitives pass through;
+/// nested `Y.Map`/`Y.Array` recurse; `Y.Text`/XML values stringify. The caller
+/// parses the JSON (yrs's own `Out::to_json` is crate-private, so we walk the
+/// `Out` variants ourselves here).
+pub fn map_json<T: ReadTxn>(txn: &T, map: &MapRef) -> String {
+    let mut pairs: Vec<(String, Any)> = map
+        .iter(txn)
+        .map(|(k, v)| (k.to_string(), out_to_any(txn, &v)))
+        .collect();
+    pairs.sort_by(|a, b| a.0.cmp(&b.0)); // deterministic key order
+    let mut out = String::from("{");
+    for (i, (k, v)) in pairs.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        // Any::to_json serializes from the start of the buffer (it doesn't
+        // append), so each piece goes into its own String, then concatenated.
+        out.push_str(&any_to_json(&Any::String(Arc::from(k.as_str())))); // JSON-escaped key
+        out.push(':');
+        out.push_str(&any_to_json(v));
+    }
+    out.push('}');
+    out
+}
+
+fn any_to_json(a: &Any) -> String {
+    let mut s = String::new();
+    a.to_json(&mut s);
+    s
+}
+
+/// Convert a yrs output value to an `Any` (which knows how to JSON-serialize),
+/// recursing through nested shared collections.
+fn out_to_any<T: ReadTxn>(txn: &T, out: &Out) -> Any {
+    match out {
+        Out::Any(a) => a.clone(),
+        Out::YText(v) => Any::from(v.get_string(txn)),
+        Out::YXmlText(v) => Any::from(v.get_string(txn)),
+        Out::YXmlElement(v) => Any::from(v.get_string(txn)),
+        Out::YXmlFragment(v) => Any::from(v.get_string(txn)),
+        Out::YArray(arr) => {
+            let items: Vec<Any> = arr.iter(txn).map(|o| out_to_any(txn, &o)).collect();
+            Any::Array(items.into())
+        }
+        Out::YMap(m) => {
+            let mut hm: HashMap<String, Any> = HashMap::new();
+            for (k, v) in m.iter(txn) {
+                hm.insert(k.to_string(), out_to_any(txn, &v));
+            }
+            Any::Map(Arc::new(hm))
+        }
+        _ => Any::Null,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yrs::{Doc, MapPrelim, Transact, XmlElementPrelim, XmlTextPrelim};
+
+    #[test]
+    fn prosemirror_blocks_keep_tags_and_separate_with_newlines() {
+        let doc = Doc::new();
+        let frag = doc.get_or_insert_xml_fragment("pm");
+        {
+            let mut txn = doc.transact_mut();
+            let h = frag.push_back(&mut txn, XmlElementPrelim::empty("heading"));
+            h.push_back(&mut txn, XmlTextPrelim::new("Title"));
+            let p = frag.push_back(&mut txn, XmlElementPrelim::empty("paragraph"));
+            p.push_back(&mut txn, XmlTextPrelim::new("Body"));
+        }
+        let txn = doc.transact();
+        assert_eq!(
+            xml_blocks_text(&txn, &frag),
+            "<heading>Title</heading>\n<paragraph>Body</paragraph>"
+        );
+    }
+
+    #[test]
+    fn lexical_style_sibling_text_blocks_separate_with_newlines() {
+        // Lexical stores each block as a sibling XmlText with no element tags;
+        // this is the case a flat read glued together.
+        let doc = Doc::new();
+        let frag = doc.get_or_insert_xml_fragment("lex");
+        {
+            let mut txn = doc.transact_mut();
+            frag.push_back(&mut txn, XmlTextPrelim::new("first paragraph"));
+            frag.push_back(&mut txn, XmlTextPrelim::new("second paragraph"));
+        }
+        let txn = doc.transact();
+        assert_eq!(
+            xml_blocks_text(&txn, &frag),
+            "first paragraph\nsecond paragraph"
+        );
+    }
+
+    #[test]
+    fn single_block_has_no_trailing_separator() {
+        let doc = Doc::new();
+        let frag = doc.get_or_insert_xml_fragment("one");
+        {
+            let mut txn = doc.transact_mut();
+            frag.push_back(&mut txn, XmlTextPrelim::new("only"));
+        }
+        let txn = doc.transact();
+        assert_eq!(xml_blocks_text(&txn, &frag), "only");
+    }
+
+    #[test]
+    fn empty_fragment_is_blank() {
+        let doc = Doc::new();
+        let frag = doc.get_or_insert_xml_fragment("empty");
+        let txn = doc.transact();
+        assert_eq!(xml_blocks_text(&txn, &frag), "");
+    }
+
+    #[test]
+    fn map_json_serializes_primitives_with_sorted_keys() {
+        let doc = Doc::new();
+        let map = doc.get_or_insert_map("state");
+        {
+            let mut txn = doc.transact_mut();
+            map.insert(&mut txn, "title", "Dashboard");
+            map.insert(&mut txn, "count", 3_i64);
+            map.insert(&mut txn, "active", true);
+        }
+        let txn = doc.transact();
+        assert_eq!(
+            map_json(&txn, &map),
+            r#"{"active":true,"count":3,"title":"Dashboard"}"#
+        );
+    }
+
+    #[test]
+    fn map_json_recurses_into_nested_map() {
+        let doc = Doc::new();
+        let map = doc.get_or_insert_map("state");
+        {
+            let mut txn = doc.transact_mut();
+            let inner = map.insert(&mut txn, "user", MapPrelim::default());
+            inner.insert(&mut txn, "name", "Ada");
+        }
+        let txn = doc.transact();
+        assert_eq!(map_json(&txn, &map), r#"{"user":{"name":"Ada"}}"#);
+    }
+
+    #[test]
+    fn map_json_empty_is_object() {
+        let doc = Doc::new();
+        let map = doc.get_or_insert_map("state");
+        let txn = doc.transact();
+        assert_eq!(map_json(&txn, &map), "{}");
+    }
+}

--- a/lib/yrb-lite-decoder.rb
+++ b/lib/yrb-lite-decoder.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Entry point matching the gem name, so `Bundler.require` works out of the box.
+require "yrb_lite/decoder"

--- a/lib/yrb_lite/decoder.rb
+++ b/lib/yrb_lite/decoder.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "yrb_lite"
+require "yrb_lite/decoder/version"
+
+module YrbLite
+  # Plain-text reconstruction of a stored Yjs document, in pure Ruby — for search
+  # indexing and previews. The core `yrb-lite` gem moves and stores opaque CRDT
+  # updates without reading them; this reads the text out of the shared type the
+  # editor uses (Lexical's `Y.XmlText`, plain `Y.Text`, or ProseMirror's
+  # `Y.XmlFragment`), in-process, on the native extension core already ships — no
+  # Node, no subprocess, no binary.
+  #
+  #   state = doc.encode_state_as_update        # opaque CRDT bytes from the store
+  #   YrbLite::Decoder.text(state)              # => "hello world"
+  #   YrbLite::Decoder.preview(state, 280)      # => "hello world…"
+  #
+  # Full-fidelity reconstruction (the exact Lexical EditorState / HTML, which
+  # needs @lexical/yjs) is a separate, opt-in concern — see the `yrb-lite-decode`
+  # package's Bun binary. This gem stays pure Ruby on purpose.
+  module Decoder
+    class Error < YrbLite::Error; end
+
+    module_function
+
+    # Plain text of the document. `field` pins the root key (Lexical: the editor
+    # id; ProseMirror: "default"); omit it to use the document's sole root.
+    def text(state, field: nil)
+      field ||= YrbLite::Doc.new.tap { |d| d.apply_update(state) }.root_names.first
+      return "" unless field
+
+      # A plain `Y.Text` root (a simple shared-text editor) reads straight out.
+      # (A yrs root's type is fixed by its first typed access, so each reader
+      # gets a fresh doc to try a different shared type against the same state.)
+      direct = load(state).read_text(field)
+      return normalize(direct) if direct && !direct.strip.empty?
+
+      # Lexical (each block a sibling `Y.XmlText`) and ProseMirror (blocks are
+      # `Y.XmlElement`s) both come back from read_xml as block-per-line markup;
+      # strip any element tags to plain text.
+      markup = load(state).read_xml(field)
+      markup ? normalize(strip_tags(markup)) : ""
+    end
+
+    # A compact, single-line preview for list UIs.
+    def preview(state, limit: 280, field: nil)
+      body = text(state, field: field).gsub(/\s+/, " ").strip
+      body.length > limit ? "#{body[0, limit].rstrip}…" : body
+    end
+
+    def load(state)
+      YrbLite::Doc.new.tap { |doc| doc.apply_update(state) }
+    end
+
+    def strip_tags(markup)
+      markup.gsub(/<[^>]*>/, " ")
+    end
+
+    def normalize(text)
+      text.gsub(/[ \t]+/, " ")     # collapse runs of spaces/tabs
+          .gsub(/ *\n */, "\n")    # trim spaces left around block separators
+          .gsub(/\n{3,}/, "\n\n")  # cap blank-line runs
+          .strip
+    end
+  end
+end

--- a/lib/yrb_lite/decoder/version.rb
+++ b/lib/yrb_lite/decoder/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module YrbLite
+  module Decoder
+    VERSION = "0.1.0.alpha1"
+  end
+end

--- a/test/decoder_test.rb
+++ b/test/decoder_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "yrb_lite/decoder"
+require "base64"
+require "json"
+
+# Decoder coverage across the major editors' Yjs storage shapes. The fixtures are
+# real CRDT states captured from each encoder:
+#   - LEXICAL:     @lexical/yjs (headless) -- two paragraphs, the 2nd ending bold.
+#   - PROSEMIRROR: the y-prosemirror / TipTap shape (Y.XmlFragment of block
+#                  Y.XmlElements) -- an <h1> then a paragraph "Plain and **bold**".
+#   - PLAINTEXT:   a plain Y.Text "content".
+# (Regenerate via packages/yrb-lite-decode, which carries the encoder deps.)
+class DecoderTest < Minitest::Test
+  # rubocop:disable Layout/LineLength -- opaque base64 CRDT fixtures, can't wrap
+  LEXICAL = "ASXk3uf5CgAHAQRyb290BigA5N7n+QoABl9fdHlwZQF3CXBhcmFncmFwaCgA5N7n+QoACF9fZm9ybWF0AX0AKADk3uf5CgAHX19zdHlsZQF3ACgA5N7n+QoACF9faW5kZW50AX0AKADk3uf5CgAFX19kaXIBfigA5N7n+QoADF9fdGV4dEZvcm1hdAF9ACgA5N7n+QoAC19fdGV4dFN0eWxlAXcABwDk3uf5CgABKADk3uf5CggGX190eXBlAXcEdGV4dCgA5N7n+QoICF9fZm9ybWF0AX0AKADk3uf5CggHX19zdHlsZQF3ACgA5N7n+QoIBl9fbW9kZQF9ACgA5N7n+QoICF9fZGV0YWlsAX0AhOTe5/kKCBJIZWxsbyBmcm9tIExleGljYWyH5N7n+QoABigA5N7n+QogBl9fdHlwZQF3CXBhcmFncmFwaCgA5N7n+QogCF9fZm9ybWF0AX0AKADk3uf5CiAHX19zdHlsZQF3ACgA5N7n+QogCF9faW5kZW50AX0AKADk3uf5CiAFX19kaXIBfigA5N7n+QogDF9fdGV4dEZvcm1hdAF9ACgA5N7n+QogC19fdGV4dFN0eWxlAXcABwDk3uf5CiABKADk3uf5CigGX190eXBlAXcEdGV4dCgA5N7n+QooCF9fZm9ybWF0AX0AKADk3uf5CigHX19zdHlsZQF3ACgA5N7n+QooBl9fbW9kZQF9ACgA5N7n+QooCF9fZGV0YWlsAX0AhOTe5/kKKAdzZWNvbmQgh+Te5/kKNAEoAOTe5/kKNQZfX3R5cGUBdwR0ZXh0KADk3uf5CjUIX19mb3JtYXQBfQEoAOTe5/kKNQdfX3N0eWxlAXcAKADk3uf5CjUGX19tb2RlAX0AKADk3uf5CjUIX19kZXRhaWwBfQCE5N7n+Qo1BGJvbGQA"
+
+  PROSEMIRROR = "AQr12Z2xBQAHAQdkZWZhdWx0AwdoZWFkaW5nKAD12Z2xBQAFbGV2ZWwBdwExh/XZnbEFAAMJcGFyYWdyYXBoBwD12Z2xBQAGBAD12Z2xBQMQQSBUaXBUYXAgSGVhZGluZwcA9dmdsQUCBgQA9dmdsQUUClBsYWluIGFuZCCG9dmdsQUeBGJvbGQEdHJ1ZYT12Z2xBR8EYm9sZIb12Z2xBSMEYm9sZARudWxsAA=="
+
+  PLAINTEXT = "AQHhwvm8AgAEAQdjb250ZW50D2p1c3QgcGxhaW4gdGV4dAA="
+
+  # A Y.Map "state" = { title: "Dashboard", count: 3, active: true, price: 9.99 }.
+  MAP = "AQSP+KW4BQAoAQVzdGF0ZQV0aXRsZQF3CURhc2hib2FyZCgBBXN0YXRlBWNvdW50AX0DKAEFc3RhdGUGYWN0aXZlAXgoAQVzdGF0ZQVwcmljZQF7QCP64UeuFHsA"
+  # rubocop:enable Layout/LineLength
+
+  def decode(b64)
+    Base64.strict_decode64(b64)
+  end
+
+  # --- Lexical / Lexxy -------------------------------------------------------
+
+  def test_lexical_blocks_are_separated_by_newlines
+    assert_equal "Hello from Lexical\nsecond bold", YrbLite::Decoder.text(decode(LEXICAL))
+  end
+
+  def test_lexical_paragraphs_do_not_merge_into_one_run
+    # Regression: Lexical's blocks are sibling Y.XmlText nodes with no element
+    # tags, so a flat read glued them ("...Lexicalsecond...") and broke word
+    # boundaries for search. read_xml now joins top-level blocks with newlines.
+    refute_includes YrbLite::Decoder.text(decode(LEXICAL)), "Lexicalsecond"
+  end
+
+  # --- ProseMirror / TipTap --------------------------------------------------
+
+  def test_prosemirror_strips_tags_and_separates_blocks
+    assert_equal "A TipTap Heading\nPlain and bold", YrbLite::Decoder.text(decode(PROSEMIRROR))
+  end
+
+  # --- plain Y.Text ----------------------------------------------------------
+
+  def test_plain_text
+    assert_equal "just plain text", YrbLite::Decoder.text(decode(PLAINTEXT))
+  end
+
+  # --- preview / field / edges ----------------------------------------------
+
+  def test_preview_collapses_to_one_line_and_truncates
+    assert_equal "Hello from Lexical second bold", YrbLite::Decoder.preview(decode(LEXICAL))
+    assert_equal "A Ti…", YrbLite::Decoder.preview(decode(PROSEMIRROR), limit: 4)
+  end
+
+  def test_field_pins_the_root
+    assert_equal "just plain text", YrbLite::Decoder.text(decode(PLAINTEXT), field: "content")
+    assert_equal "", YrbLite::Decoder.text(decode(PLAINTEXT), field: "no-such-root")
+  end
+
+  def test_empty_document_is_blank
+    assert_equal "", YrbLite::Decoder.text(YrbLite::Doc.new.encode_state_as_update)
+  end
+
+  # --- native Doc readers underneath ----------------------------------------
+
+  def test_doc_readers_cover_each_shape
+    assert_equal ["root"], YrbLite::Decoder.load(decode(LEXICAL)).root_names
+    # Lexical/ProseMirror roots aren't plain text, so read_text is empty there;
+    # read_xml carries the block-separated content.
+    assert_equal "", YrbLite::Decoder.load(decode(LEXICAL)).read_text("root").to_s.strip
+    assert_includes YrbLite::Decoder.load(decode(LEXICAL)).read_xml("root"), "\n"
+    assert_equal "just plain text", YrbLite::Decoder.load(decode(PLAINTEXT)).read_text("content")
+  end
+
+  # --- read_map (structured state) ------------------------------------------
+
+  def test_read_map_returns_state_as_json
+    doc = YrbLite::Doc.new
+    doc.apply_update(decode(MAP))
+
+    assert_equal(
+      { "title" => "Dashboard", "count" => 3, "active" => true, "price" => 9.99 },
+      JSON.parse(doc.read_map("state"))
+    )
+  end
+
+  def test_read_map_missing_root_is_nil
+    doc = YrbLite::Doc.new
+    doc.apply_update(decode(MAP))
+
+    assert_nil doc.read_map("nope")
+  end
+end

--- a/yrb-lite-decoder.gemspec
+++ b/yrb-lite-decoder.gemspec
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require_relative "lib/yrb_lite/decoder/version"
+
+Gem::Specification.new do |spec|
+  spec.name = "yrb-lite-decoder"
+  spec.version = YrbLite::Decoder::VERSION
+  spec.authors = ["JP Camara"]
+  spec.email = ["johnpcamara@gmail.com"]
+
+  spec.summary = "Pure-Ruby plain-text reconstruction of a stored Yjs document, for search indexing and previews"
+  spec.description = "yrb-lite-decoder reads the text out of a stored Yjs CRDT state in pure Ruby — Lexical's " \
+                     "Y.XmlText, plain Y.Text, or ProseMirror's Y.XmlFragment — on the native extension the core " \
+                     "yrb-lite gem already ships. No Node, no subprocess, no binary: ideal for search indexing and " \
+                     "previews. Full-fidelity Lexical EditorState / HTML reconstruction is a separate, opt-in concern " \
+                     "(the yrb-lite-decode Bun binary)."
+  spec.homepage = "https://github.com/jpcamara/yrb-lite"
+  spec.license = "MIT"
+  spec.required_ruby_version = ">= 3.4.0"
+
+  spec.files = Dir[
+    "lib/yrb-lite-decoder.rb",
+    "lib/yrb_lite/decoder.rb",
+    "lib/yrb_lite/decoder/**/*.rb",
+    "LICENSE",
+    "README.md",
+    "CHANGELOG-decoder.md"
+  ]
+  spec.require_paths = ["lib"]
+
+  spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG-decoder.md"
+  spec.metadata["bug_tracker_uri"] = "#{spec.homepage}/issues"
+  spec.metadata["rubygems_mfa_required"] = "true"
+
+  spec.add_dependency "base64", "~> 0.2"
+  # Needs the Doc content readers (root_names / read_text / read_xml). Bump the
+  # floor to the first published core release that ships them.
+  spec.add_dependency "yrb-lite", ">= 0.1.0.beta7"
+
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+end


### PR DESCRIPTION
Splits the original decoder PR (#27) into its two independent halves; this is the **Rust + Ruby** half.

- Native `Doc` readers (Rust): `root_names`, `read_text`, `read_xml` (block-separated for Lexical/ProseMirror), `read_map` (Y.Map → JSON). Walk/serialize logic is in pure, Rust-tested functions in `read.rs`; `lib.rs` is a thin binding.
- `yrb-lite-decoder` gem: pure-Ruby text/preview across Lexical `Y.XmlText`, plain `Y.Text`, ProseMirror `Y.XmlFragment`, with block boundaries preserved.
- 14 Rust unit tests + per-format Ruby fixtures.

The full-fidelity Bun binary is the companion PR (feat/decoder-bun).