### PR TITLE
Fix update_advances? to be exact for delete-bearing updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-07-01
+
+### Fixed
+
+- `Doc#update_advances?` is now exact for **delete-bearing** updates, so an
+  already-applied pure-delete retry no longer reports as advancing. Previously any
+  update carrying a delete set returned `true` (record it) because deletes don't
+  move the state vector, so the cheap state-vector probe couldn't prove a
+  duplicate. A lost-ack retry of a deletion the server had already integrated was
+  therefore re-recorded and re-broadcast every time. For delete-bearing updates we
+  now compare the full encoded document state (which includes the delete set)
+  before vs. after a trial apply on an isolated probe: a genuinely new deletion
+  changes it (`true`); an already-applied retry re-encodes identically (`false`).
+  Insert/format-only updates keep the cheaper state-vector path, so only
+  delete-bearing frames — a minority — pay for the exact comparison. The exactly-
+  once guarantee is unchanged in the safe direction: a real deletion is never
+  dropped.
+
+  This lets `yrby-actioncable` (and any caller gating `on_change` on
+  `update_advances?`) settle a duplicate pure-delete frame as `:applied` — acked,
+  but not stored or relayed — so apps no longer need an app-level
+  encode-and-compare guard around their durable writes.
+
 ## [0.2.2] - 2026-06-30
 
 ### Fixed

--- a/ext/yrby/src/protocol.rs
+++ b/ext/yrby/src/protocol.rs
@@ -77,26 +77,38 @@ pub(crate) fn update_is_ready(doc: &Doc, update_bytes: &[u8]) -> Result<bool, St
 }
 
 /// True if applying `update_bytes` would actually change `doc`, i.e. it carries
-/// content the doc doesn't already have. This lets the server make durable side
-/// effects exactly-once: a lost-ack retry re-sends an update the server already
-/// applied; that retry is causally ready (so `update_is_ready` is true) but must
-/// not re-run `on_change`.
+/// content (an insert, a format, or a deletion) the doc doesn't already have.
+/// This lets the server make durable side effects exactly-once: a lost-ack retry
+/// re-sends an update the server already applied; that retry is causally ready
+/// (so `update_is_ready` is true) but must not re-run `on_change`.
 ///
 /// We can't read the update's own state vector to decide this: yrs reports an
 /// empty state_vector() for a causally-pending diff (e.g. a resync delta whose
 /// structs depend on updates the doc has but the standalone update doesn't),
-/// which would look identical to a no-op. So measure the real effect: seed an
-/// independent probe with the doc's current state, apply the update there, and
-/// see whether the state vector grew. Deletes don't move the state vector, so we
-/// can't cheaply prove a delete-bearing update is a duplicate; we conservatively
-/// report it as advancing (record it). That can still double-record a pure-delete
-/// retry, but it never drops a real deletion, which is the safe direction.
-/// Assumes the update is already causally ready.
+/// which would look identical to a no-op. So measure the real effect on an
+/// independent probe seeded with the doc's current state (never mutating the real
+/// doc), then compare the probe before and after applying the update:
+///
+/// - **Insert/format-only updates** grow the probe's state vector, so comparing
+///   the state vector is enough — and cheaper than a full re-encode.
+/// - **Delete-bearing updates** don't move the state vector (a deletion tombstones
+///   an existing struct rather than adding one), so we compare the full encoded
+///   state, which carries the delete set. An already-applied pure-delete retry
+///   re-encodes byte-identically → false; a genuinely new deletion changes the
+///   delete set → true. This is exact but pays for two full encodes, so only
+///   delete-bearing frames — a minority — take that path.
+///
+/// Earlier this branch was conservative: any delete-bearing update returned true
+/// (record it), which double-recorded and re-broadcast pure-delete retries the
+/// server had already integrated. The exact comparison removes that duplication
+/// while still never dropping a real deletion. Assumes the update is already
+/// causally ready.
 pub(crate) fn update_advances_doc(doc: &Doc, update_bytes: &[u8]) -> Result<bool, String> {
     let update = yrs::Update::decode_v1(update_bytes).map_err(|e| e.to_string())?;
-    if !update.delete_set().is_empty() {
-        return Ok(true); // can't cheaply prove a delete is a duplicate; record it
-    }
+    let has_deletes = !update.delete_set().is_empty();
+
+    // Seed an independent probe with the doc's current state so we can measure the
+    // update's effect without mutating the real doc.
     let probe = Doc::new();
     let current = doc
         .transact()
@@ -105,13 +117,30 @@ pub(crate) fn update_advances_doc(doc: &Doc, update_bytes: &[u8]) -> Result<bool
         .transact_mut()
         .apply_update(yrs::Update::decode_v1(&current).map_err(|e| e.to_string())?)
         .map_err(|e| e.to_string())?;
-    let before = probe.transact().state_vector();
-    probe
-        .transact_mut()
-        .apply_update(update)
-        .map_err(|e| e.to_string())?;
-    let after = probe.transact().state_vector();
-    Ok(after != before)
+
+    if has_deletes {
+        // Deletes don't move the state vector; compare the full encoded state
+        // (which includes the delete set), before vs. after, on the same probe.
+        let before = probe
+            .transact()
+            .encode_state_as_update_v1(&yrs::StateVector::default());
+        probe
+            .transact_mut()
+            .apply_update(update)
+            .map_err(|e| e.to_string())?;
+        let after = probe
+            .transact()
+            .encode_state_as_update_v1(&yrs::StateVector::default());
+        Ok(before != after)
+    } else {
+        let before = probe.transact().state_vector();
+        probe
+            .transact_mut()
+            .apply_update(update)
+            .map_err(|e| e.to_string())?;
+        let after = probe.transact().state_vector();
+        Ok(before != after)
+    }
 }
 
 /// True if the doc holds pending structs or a pending delete set: blocks that
@@ -243,6 +272,87 @@ mod tests {
         assert!(
             !update_advances_doc(&server, &diff).unwrap(),
             "the byte-identical retry of that diff does not advance"
+        );
+    }
+
+    #[test]
+    fn update_advances_is_exact_for_pure_delete_retries() {
+        // Build "hello", snapshot the pre-delete content, then delete a char and
+        // capture just that deletion as a diff (only a delete set, no new structs).
+        let doc = Doc::new();
+        let text = doc.get_or_insert_text("content");
+        text.insert(&mut doc.transact_mut(), 0, "hello");
+        let content_state = doc
+            .transact()
+            .encode_state_as_update_v1(&yrs::StateVector::default());
+        let sv_before = doc.transact().state_vector();
+        text.remove_range(&mut doc.transact_mut(), 0, 1); // delete "h"
+        let delete = doc.transact().encode_state_as_update_v1(&sv_before);
+
+        assert!(
+            !yrs::Update::decode_v1(&delete)
+                .unwrap()
+                .delete_set()
+                .is_empty(),
+            "the diff carries a delete set"
+        );
+
+        // A server holding the pre-delete content, but not the deletion yet.
+        let server = Doc::new();
+        server
+            .transact_mut()
+            .apply_update(yrs::Update::decode_v1(&content_state).unwrap())
+            .unwrap();
+
+        // The deletion is new: it advances (must be recorded).
+        assert!(
+            update_advances_doc(&server, &delete).unwrap(),
+            "a not-yet-applied deletion advances the doc"
+        );
+
+        // Apply it; now the byte-identical pure-delete retry must NOT advance.
+        // (This is the behavior change: it used to conservatively return true.)
+        server
+            .transact_mut()
+            .apply_update(yrs::Update::decode_v1(&delete).unwrap())
+            .unwrap();
+        assert!(
+            !update_advances_doc(&server, &delete).unwrap(),
+            "an already-applied pure-delete retry does not advance"
+        );
+    }
+
+    #[test]
+    fn update_advances_for_a_delete_bundled_with_new_content() {
+        // A delete-bearing update that ALSO carries a new struct still advances,
+        // even after the pure-delete part would be a no-op on its own.
+        let doc = Doc::new();
+        let text = doc.get_or_insert_text("content");
+        text.insert(&mut doc.transact_mut(), 0, "hello");
+        let content_state = doc
+            .transact()
+            .encode_state_as_update_v1(&yrs::StateVector::default());
+        let sv_before = doc.transact().state_vector();
+        text.remove_range(&mut doc.transact_mut(), 0, 1); // delete "h"
+        text.insert(&mut doc.transact_mut(), 4, "!"); // and add "!"
+        let mixed = doc.transact().encode_state_as_update_v1(&sv_before);
+
+        let server = Doc::new();
+        server
+            .transact_mut()
+            .apply_update(yrs::Update::decode_v1(&content_state).unwrap())
+            .unwrap();
+        assert!(
+            update_advances_doc(&server, &mixed).unwrap(),
+            "an insert+delete update advances"
+        );
+        server
+            .transact_mut()
+            .apply_update(yrs::Update::decode_v1(&mixed).unwrap())
+            .unwrap();
+        assert!(
+            !update_advances_doc(&server, &mixed).unwrap(),
+            "its byte-identical retry does not advance"
         );
     }
 

--- a/lib/y/version.rb
+++ b/lib/y/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Y
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/test/fixtures/generate_fixtures.mjs
+++ b/test/fixtures/generate_fixtures.mjs
@@ -72,6 +72,22 @@ const concurrentClients = (() => {
   })
 })()
 
+// Fixture 8: a deletion delivered as its own delta. Insert "hello" (client 1),
+// snapshot that state, then delete the first char and capture the incremental
+// update. The deletion diff carries only a delete set (no new structs), so
+// re-applying it is a no-op -- the shape a lost-ack retry takes.
+const deleteRetry = (() => {
+  const doc = new Y.Doc()
+  doc.clientID = 1
+  const t = doc.getText("content")
+  t.insert(0, "hello")
+  const content = Y.encodeStateAsUpdate(doc)
+  const sv = Y.encodeStateVector(doc)
+  t.delete(0, 1) // delete "h"
+  const deletion = Y.encodeStateAsUpdate(doc, sv) // just the deletion, as a diff
+  return { content: b64(content), deletion: b64(deletion) }
+})()
+
 // Fixture 7: a real awareness (presence) message frame, client 42 with a user
 // and cursor, exactly as a browser client emits it: MSG_AWARENESS (1) wrapping
 // an encoded awareness update.
@@ -165,6 +181,16 @@ module YjsFixtures
   # frame instead of generating one server-side.
   module Presence
     FRAME = YjsFixtures.b64("${presence}")
+  end
+
+  # Fixture 8: a deletion delivered as its own delta. CONTENT inserts "hello"
+  # (client 1); DELETION is the incremental update that deletes the first char.
+  # DELETION carries only a delete set (no new structs), so re-applying it is a
+  # no-op -- the exactly-once guard records/broadcasts it once, then treats the
+  # lost-ack retry as already-applied (acked, not re-recorded).
+  module DeleteRetry
+    CONTENT = YjsFixtures.b64("${deleteRetry.content}")
+    DELETION = YjsFixtures.b64("${deleteRetry.deletion}")
   end
 end
 `

--- a/test/fixtures/yjs_fixtures.rb
+++ b/test/fixtures/yjs_fixtures.rb
@@ -71,4 +71,14 @@ module YjsFixtures
   module Presence
     FRAME = YjsFixtures.b64("AS0BKgEpeyJjdXJzb3IiOnsieCI6MTAsInkiOjIwfSwidXNlciI6ImFsaWNlIn0=")
   end
+
+  # Fixture 8: a deletion delivered as its own delta. CONTENT inserts "hello"
+  # (client 1); DELETION is the incremental update that deletes the first char.
+  # DELETION carries only a delete set (no new structs), so re-applying it is a
+  # no-op -- the exactly-once guard records/broadcasts it once, then treats the
+  # lost-ack retry as already-applied (acked, not re-recorded).
+  module DeleteRetry
+    CONTENT = YjsFixtures.b64("AQEBAAQBB2NvbnRlbnQFaGVsbG8A")
+    DELETION = YjsFixtures.b64("AAEBAQAB")
+  end
 end

--- a/test/sync_test.rb
+++ b/test/sync_test.rb
@@ -380,6 +380,27 @@ class SyncTest < Minitest::Test
     assert_equal [5, 5], acks_in(transmits)
   end
 
+  def test_lost_ack_delete_retry_acks_without_double_recording
+    # A pure-delete retry the server already integrated must be acked but not
+    # recorded or re-broadcast. Insert content, delete a char, then replay the
+    # deletion: the second delivery is a no-op the guard must catch.
+    content = YjsFixtures::DeleteRetry::CONTENT
+    deletion = YjsFixtures::DeleteRetry::DELETION
+
+    store = []
+    broadcasts = []
+    transmits = []
+    helper = helper_for(store: store, transmits: transmits, broadcasts: broadcasts)
+
+    helper.sync_receive(update_message(content, id: 1), "doc-key")
+    helper.sync_receive(update_message(deletion, id: 2), "doc-key")
+    helper.sync_receive(update_message(deletion, id: 3), "doc-key") # lost-ack retry
+
+    assert_equal 2, store.length, "the deletion records once; its retry does not"
+    assert_equal 2, broadcasts.length, "the retry is not re-broadcast"
+    assert_equal [1, 2, 3], acks_in(transmits), "every frame is still acked"
+  end
+
   # -- Store-backed concurrency -------------------------------------------
   #
   # Real MRI threads contend on one document key. Delivery is at-least-once, so a


### PR DESCRIPTION
## Prod issue

On docs with pure-delete retries, `yrby-actioncable` re-recorded and re-broadcast deletions the server had **already** integrated. `Doc#update_advances?` returned `true` for *any* delete-bearing update, so a lost-ack retry of a deletion looked like it advanced the doc every time — durable spam (duplicate rows, extra broadcasts, history-job noise) that the app had to compensate for with its own encode-and-compare guard around every write.

## Root cause

Deletes don't move the state vector (a deletion tombstones an existing struct rather than adding one), so the cheap state-vector-growth probe couldn't tell a *new* deletion from an *already-applied* one. The old code took the safe-but-blunt route: any delete set ⇒ `true` (record it).

```rust
if !update.delete_set().is_empty() {
    return Ok(true); // can't cheaply prove a delete is a duplicate; record it
}
```

## Fix

Measure the real effect on an isolated probe (never mutating the real doc), then branch on how to compare:

- **Insert/format-only** updates grow the state vector → compare that (cheap, unchanged).
- **Delete-bearing** updates → compare the **full encoded document state** (which carries the delete set) before vs. after the trial apply. A genuinely new deletion changes it (`true`); an already-applied retry re-encodes byte-identically (`false`).

Only delete-bearing frames — a minority — pay for the exact comparison. The exactly-once guarantee is unchanged in the safe direction: **a real deletion is never dropped.**

This flows straight through `sync.rb`'s existing gate:

```ruby
return :applied unless doc.update_advances?(update)  # now: dup pure-delete => :applied
sync_record_change(update)
sync_distribute(encoded)
```

A duplicate pure-delete frame is now acked but **not** stored or relayed — so **the app-level replay-and-compare guard can be removed**.

## Tests

- **`protocol.rs`** — a pure-delete retry does not advance; a delete bundled with a new insert still advances (and its byte-identical retry does not).
- **`sync_test.rb`** — end-to-end ActionCable: a lost-ack delete retry is acked (`[1,2,3]`) but recorded/broadcast only once. Uses a new `DeleteRetry` fixture generated from **real Y.js** (added to `generate_fixtures.mjs`; the Y.js-emitted delete bytes match yrby's byte-for-byte).
- Full suite green: 77 Ruby runs, 17 Rust tests, clippy + rustfmt + rubocop clean.

Bumps yrby to **0.2.3**.

> Note: independent of the live-maps PR (#33). If that merges first, this needs a trivial version/CHANGELOG reconcile (0.2.3 → 0.3.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)