### PR TITLE
yrby-actioncable 0.2.2: raise yrby floor to >= 0.2.3

### DIFF
--- a/CHANGELOG-actioncable.md
+++ b/CHANGELOG-actioncable.md
@@ -6,6 +6,18 @@ this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-07-01
+
+### Changed
+- Raised the `yrby` floor to `>= 0.2.3`. That release makes `Doc#update_advances?`
+  exact for **delete-bearing** updates. The sync channel gates durable
+  record-before-distribute on `update_advances?` (`return :applied unless
+  doc.update_advances?(update)`), so with an older core a lost-ack retry of a
+  deletion the server had already integrated was re-recorded and re-broadcast
+  each time. No code change here — pinning the floor just makes the gem's
+  exactly-once durable-recording guarantee self-enforcing instead of dependent on
+  the app updating the core gem.
+
 ## [0.2.1] - 2026-06-29
 
 ### Changed

--- a/lib/y/action_cable/version.rb
+++ b/lib/y/action_cable/version.rb
@@ -2,6 +2,6 @@
 
 module Y
   module ActionCable
-    VERSION = "0.2.1"
+    VERSION = "0.2.2"
   end
 end

--- a/yrby-actioncable.gemspec
+++ b/yrby-actioncable.gemspec
@@ -33,8 +33,10 @@ Gem::Specification.new do |spec|
   spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.add_dependency "base64", "~> 0.2"
-  # Floor raised for update_advances? + wire client-id frame validation.
-  spec.add_dependency "yrby", ">= 0.2.1"
+  # Floor raised to 0.2.3, whose update_advances? is exact for delete-bearing
+  # updates -- the channel gates durable record-before-distribute on it, so the
+  # floor makes the exactly-once guarantee self-enforcing (not app-dependent).
+  spec.add_dependency "yrby", ">= 0.2.3"
   # The concern references ActionCable (channels, streaming, broadcasting) and
   # ActiveSupport (Concern, JSON coder) constants directly. Rails apps already
   # bundle these, but declaring them makes use outside a full Rails bundle fail


### PR DESCRIPTION
Bumps **yrby-actioncable 0.2.1 → 0.2.2**, raising the `yrby` dependency floor `>= 0.2.1` → `>= 0.2.3`. No code change.

## Why

The channel gates durable record-before-distribute on `update_advances?`:

```ruby
return :applied unless doc.update_advances?(update)  # sync.rb:276
sync_record_change(update)
sync_distribute(encoded)
```

yrby 0.2.3 makes `update_advances?` exact for delete-bearing updates. With an older core, a lost-ack retry of a deletion the server had already integrated was re-recorded and re-broadcast every time. The gem advertises exactly-once durable recording, but with the floor at `>= 0.2.1` that guarantee silently depended on the app also updating core.

Raising the floor to `>= 0.2.3` makes the guarantee **self-enforcing** — installing/upgrading yrby-actioncable now pulls a core that actually delivers it.

Pure-Ruby, single gem, no precompilation. Built gem's dependency confirmed: `yrby >= 0.2.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)