### PR TITLE
Serve gap-free sync state + Doc#pending? / #compacted_state_update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-01
+
+### Fixed
+
+- **Sync no longer serves un-integrable pending structs.** When a doc holds a
+  *pending* struct (a gappy update whose causally-prior update is missing — e.g.
+  legacy data recorded before the `update_ready?` gate existed), its integrated
+  state vector is empty but `encode_state_as_update` merges the pending bytes back
+  in. Answering a peer's `SyncStep1` with that state handed the peer content it
+  couldn't integrate, so it parked the same pending forever and the empty-SV /
+  non-empty-content mismatch drove endless resync traffic (observed as a browser
+  re-sending frames several times a second). `handle_sync_message` now answers
+  `SyncStep1` with **integrated-only** state, so a server never serves a struct it
+  can't integrate itself. Neutralizes existing poisoned server state on deploy —
+  no migration needed. The server's own pending is untouched and still heals if
+  the missing dependency later arrives (only then does the content become
+  visible in sync). Live delta relay (`Update` frames) is unchanged.
+
+### Added
+
+- `Doc#pending?` — true if the doc holds un-integrable pending structs or a
+  pending delete set (content waiting on a missing causally-prior update).
+- `Doc#compacted_state_update` — like `encode_state_as_update` (full state) but
+  **gap-free**: excludes pending structs/delete set. Use it when persisting or
+  serving state other peers will apply. Non-destructive — the doc keeps its
+  pending (so it can still heal), and `encode_state_as_update` stays lossless for
+  raw-update recovery.
+
 ## [0.2.3] - 2026-07-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -142,17 +142,38 @@ doc = Y::Doc.new(12345) # specific client ID (used for CRDT identity)
 
 # Encoding
 doc.encode_state_vector           # => current state vector
-doc.encode_state_as_update        # => full update
+doc.encode_state_as_update        # => full update (lossless: keeps pending)
 doc.encode_state_as_update(sv)    # => update diff against state vector
+doc.compacted_state_update        # => full update, gap-free (excludes pending)
 
 # Applying updates
 doc.apply_update(update_bytes)    # apply raw V1 update
+doc.pending?                      # => true if holding un-integrable pending structs
 
 # Sync protocol
 doc.sync_step1                    # => SyncStep1 message (this doc's state vector)
 doc.handle_sync_message(data)     # => [msg_type, sync_type, response]; answers a
-                                  #    peer's SyncStep1 with a SyncStep2
+                                  #    peer's SyncStep1 with an integrated-only
+                                  #    SyncStep2 (never serves pending structs)
 ```
+
+### Pending structs and gap-free state
+
+If a doc applies an update whose causally-prior update is missing (a "gappy"
+update), yrs parks it as a **pending** struct: the integrated state vector stays
+empty, but the pending block is held as a recovery buffer and heals if the
+missing dependency later arrives. `Doc#pending?` reports this.
+
+Pending structs are *not* document state, so they must not cross the sync
+boundary — a peer that receives one can't integrate it and gets stuck. Two
+guarantees keep serving safe:
+
+- `handle_sync_message` answers `SyncStep1` with **integrated-only** state, so a
+  server never serves a struct it can't integrate itself (this is automatic).
+- `Doc#compacted_state_update` gives you the same gap-free full-state update for
+  when you persist or hand off state yourself. It's non-destructive (the doc
+  keeps its pending), while `encode_state_as_update` stays lossless so you can
+  still preserve the raw pending bytes for recovery.
 
 ### Protocol codec (module functions)
 

--- a/ext/yrby/src/lib.rs
+++ b/ext/yrby/src/lib.rs
@@ -8,7 +8,10 @@ use yrs::{Doc, GetString, ReadTxn, Transact};
 
 mod protocol;
 mod read;
-use protocol::{classify_message, merged_doc_update, update_advances_doc, update_is_ready};
+use protocol::{
+    classify_message, has_pending, integrated_update, merged_doc_update, update_advances_doc,
+    update_is_ready,
+};
 
 /// Wrapper around yrs Doc.
 ///
@@ -188,6 +191,28 @@ impl RbDoc {
         })
     }
 
+    /// True if the doc holds un-integrable pending structs or a pending delete
+    /// set — content that couldn't integrate because a causally-prior update is
+    /// missing. Such content is a recovery buffer, not document state; it heals if
+    /// the missing dependency later arrives. A pure read.
+    fn pending(&self) -> bool {
+        let doc = &self.0;
+        nogvl(move || has_pending(doc))
+    }
+
+    /// Like `encode_state_as_update` (full state), but **gap-free**: it excludes
+    /// any pending (un-integrable) structs and pending delete set. Use this when
+    /// persisting or serving state that other peers will apply — serving pending
+    /// content poisons their sync. Non-destructive: this doc keeps its pending, so
+    /// a genuine gap still heals if its dependency arrives. (`encode_state_as_update`
+    /// stays lossless for raw-update recovery.)
+    fn compacted_state_update(&self) -> Result<RString, Error> {
+        let doc = &self.0;
+        let update = nogvl(move || integrated_update(doc, &yrs::StateVector::default()))
+            .map_err(yrb_error)?;
+        Ok(binary_string(&update))
+    }
+
     /// Encode state as update (optionally diffed against a state vector)
     fn encode_state_as_update(&self, args: &[Value]) -> Result<RString, Error> {
         let sv_bytes: Option<Vec<u8>> = if args.is_empty() {
@@ -263,9 +288,13 @@ impl RbDoc {
                 match msg {
                     Message::Sync(sync_msg) => match sync_msg {
                         SyncMessage::SyncStep1(sv) => {
-                            // Respond with SyncStep2
-                            let txn = doc.transact();
-                            let update = txn.encode_state_as_update_v1(&sv);
+                            // Respond with SyncStep2 carrying only *integrated*
+                            // state. Never hand a peer un-integrable pending
+                            // structs: the peer would park the same pending
+                            // forever and the state-vector/content mismatch drives
+                            // endless resync traffic. (integrated_update is a no-op
+                            // fast path when nothing is pending.)
+                            let update = integrated_update(doc, &sv)?;
                             let response = Message::Sync(SyncMessage::SyncStep2(update));
                             Ok((0, 0, response.encode_v1()))
                         }
@@ -366,6 +395,11 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     doc_class.define_method("read_text", method!(RbDoc::read_text, 1))?;
     doc_class.define_method("read_xml", method!(RbDoc::read_xml, 1))?;
     doc_class.define_method("read_map", method!(RbDoc::read_map, 1))?;
+    doc_class.define_method("pending?", method!(RbDoc::pending, 0))?;
+    doc_class.define_method(
+        "compacted_state_update",
+        method!(RbDoc::compacted_state_update, 0),
+    )?;
     doc_class.define_method("update_ready?", method!(RbDoc::update_ready, 1))?;
     doc_class.define_method("update_advances?", method!(RbDoc::update_advances, 1))?;
     doc_class.define_method("sync_step1", method!(RbDoc::sync_step1, 0))?;

--- a/ext/yrby/src/protocol.rs
+++ b/ext/yrby/src/protocol.rs
@@ -8,7 +8,7 @@ use yrs::encoding::read::{Cursor, Read};
 use yrs::sync::protocol::MessageReader;
 use yrs::sync::{Message, SyncMessage};
 use yrs::updates::decoder::{Decode, DecoderV1};
-use yrs::{Doc, ReadTxn, Transact};
+use yrs::{Doc, ReadTxn, StateVector, Transact, Update, WriteTxn};
 
 /// Classify a frame: a non-zero code only for exactly one well-formed message
 /// that consumes the whole buffer (the codes are the match arms below).
@@ -143,13 +143,44 @@ pub(crate) fn update_advances_doc(doc: &Doc, update_bytes: &[u8]) -> Result<bool
     }
 }
 
-/// True if the doc holds pending structs or a pending delete set: blocks that
-/// couldn't integrate because a dependency is missing. Test-only: asserts the
-/// causal-chain parking behavior in the unit tests below.
-#[cfg(test)]
-pub(crate) fn doc_has_pending(doc: &Doc) -> bool {
+/// True if the doc holds un-integrable pending structs or a pending delete set:
+/// blocks that couldn't integrate because a causally-prior update is missing. A
+/// pure read; does not mutate.
+pub(crate) fn has_pending(doc: &Doc) -> bool {
     let txn = doc.transact();
     txn.store().pending_update().is_some() || txn.store().pending_ds().is_some()
+}
+
+/// Encode the doc's **integrated** state as a v1 update diffed against `sv`,
+/// excluding any pending (un-integrable) structs and pending delete set.
+///
+/// Pending blocks are a recovery buffer, not document state. Serving them across
+/// the sync boundary hands a peer content it can't integrate, so the peer parks
+/// the same pending forever and the state-vector/content mismatch drives endless
+/// resync traffic. `encode_state_as_update_v1` merges pending back in (see yrs
+/// `merge_pending_v1`), so to get a gap-free encode we rebuild the state into a
+/// throwaway doc and `prune_pending` there before re-encoding.
+///
+/// Non-destructive: the prune happens only on the throwaway copy; `doc` keeps its
+/// pending, so a genuine gap still heals if its missing dependency later arrives.
+pub(crate) fn integrated_update(doc: &Doc, sv: &StateVector) -> Result<Vec<u8>, String> {
+    // Fast path: with nothing pending the direct encode is already gap-free, so
+    // the clean common case keeps the zero-copy behavior.
+    if !has_pending(doc) {
+        return Ok(doc.transact().encode_state_as_update_v1(sv));
+    }
+    let full = doc
+        .transact()
+        .encode_state_as_update_v1(&StateVector::default());
+    let clean = Doc::new();
+    {
+        let mut txn = clean.transact_mut();
+        txn.apply_update(Update::decode_v1(&full).map_err(|e| e.to_string())?)
+            .map_err(|e| e.to_string())?;
+        txn.prune_pending();
+    }
+    let out = clean.transact().encode_state_as_update_v1(sv);
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -157,7 +188,7 @@ mod tests {
     use super::*;
     use yrs::sync::Awareness;
     use yrs::updates::encoder::Encode;
-    use yrs::Text;
+    use yrs::{GetString, Text};
 
     fn text_update(content: &str) -> Vec<u8> {
         let doc = Doc::new();
@@ -418,24 +449,107 @@ mod tests {
             !update_is_ready(&doc, u3).unwrap(),
             "u3 depends on the missing u2"
         );
-        assert!(
-            !doc_has_pending(&doc),
-            "nothing pending until u3 is applied"
-        );
+        assert!(!has_pending(&doc), "nothing pending until u3 is applied");
 
         // Applying u3 anyway parks it as a pending struct.
         doc.transact_mut()
             .apply_update(yrs::Update::decode_v1(u3).unwrap())
             .unwrap();
-        assert!(
-            doc_has_pending(&doc),
-            "u3 is pending: its parent u2 is missing"
-        );
+        assert!(has_pending(&doc), "u3 is pending: its parent u2 is missing");
 
         // Once u2 arrives (via resync), u3 integrates and pending clears.
         doc.transact_mut()
             .apply_update(yrs::Update::decode_v1(u2).unwrap())
             .unwrap();
-        assert!(!doc_has_pending(&doc), "u2 arrived; u3 integrated");
+        assert!(!has_pending(&doc), "u2 arrived; u3 integrated");
+    }
+
+    // Build a causal gap: `first` inserts "a", `dependent` inserts "b" after it,
+    // so `dependent` alone parks as pending on a doc that lacks `first`.
+    fn gap_pair() -> (Vec<u8>, Vec<u8>) {
+        let src = Doc::new();
+        let txt = src.get_or_insert_text("notepad");
+        txt.insert(&mut src.transact_mut(), 0, "a");
+        let first = src
+            .transact()
+            .encode_state_as_update_v1(&yrs::StateVector::default());
+        let sv = src.transact().state_vector();
+        txt.insert(&mut src.transact_mut(), 1, "b");
+        let dependent = src.transact().encode_state_as_update_v1(&sv);
+        (first, dependent)
+    }
+
+    #[test]
+    fn integrated_update_strips_pending_and_is_non_destructive() {
+        let (_first, dependent) = gap_pair();
+        let doc = Doc::new();
+        doc.transact_mut()
+            .apply_update(yrs::Update::decode_v1(&dependent).unwrap())
+            .unwrap();
+        assert!(has_pending(&doc), "the gappy update parked as pending");
+
+        // encode_state_as_update carries the pending; integrated_update does not.
+        let full = doc
+            .transact()
+            .encode_state_as_update_v1(&yrs::StateVector::default());
+        let gap_free = integrated_update(&doc, &yrs::StateVector::default()).unwrap();
+        assert_ne!(full, gap_free, "integrated_update drops the pending bytes");
+
+        // Applying the gap-free encode to a fresh peer must NOT poison it.
+        let peer = Doc::new();
+        peer.transact_mut()
+            .apply_update(yrs::Update::decode_v1(&gap_free).unwrap())
+            .unwrap();
+        assert!(
+            !has_pending(&peer),
+            "peer got no pending from the gap-free state"
+        );
+
+        // Non-destructive: the source doc keeps its pending (so it can still heal).
+        assert!(
+            has_pending(&doc),
+            "integrated_update did not mutate the source"
+        );
+    }
+
+    #[test]
+    fn integrated_update_fast_path_matches_direct_encode_when_clean() {
+        // No pending -> byte-identical to encode_state_as_update (zero-copy path).
+        let (first, _dependent) = gap_pair();
+        let doc = Doc::new();
+        doc.transact_mut()
+            .apply_update(yrs::Update::decode_v1(&first).unwrap())
+            .unwrap();
+        assert!(!has_pending(&doc));
+        let direct = doc
+            .transact()
+            .encode_state_as_update_v1(&yrs::StateVector::default());
+        let via = integrated_update(&doc, &yrs::StateVector::default()).unwrap();
+        assert_eq!(direct, via);
+    }
+
+    #[test]
+    fn a_healed_gap_serves_its_content() {
+        // After the missing dependency arrives, the (formerly pending) content is
+        // integrated and integrated_update includes it.
+        let (first, dependent) = gap_pair();
+        let doc = Doc::new();
+        doc.transact_mut()
+            .apply_update(yrs::Update::decode_v1(&dependent).unwrap())
+            .unwrap();
+        doc.transact_mut()
+            .apply_update(yrs::Update::decode_v1(&first).unwrap())
+            .unwrap();
+        assert!(!has_pending(&doc), "gap healed once first arrived");
+        let gap_free = integrated_update(&doc, &yrs::StateVector::default()).unwrap();
+        let peer = Doc::new();
+        peer.transact_mut()
+            .apply_update(yrs::Update::decode_v1(&gap_free).unwrap())
+            .unwrap();
+        assert_eq!(
+            peer.get_or_insert_text("notepad")
+                .get_string(&peer.transact()),
+            "ab"
+        );
     }
 }

--- a/ext/yrby/src/protocol.rs
+++ b/ext/yrby/src/protocol.rs
@@ -552,4 +552,107 @@ mod tests {
             "ab"
         );
     }
+
+    // A gappy insert from its own independent client: inserts two chars and
+    // returns only the second delta, which depends on the (missing) first.
+    fn independent_gappy_insert() -> Vec<u8> {
+        let src = Doc::new();
+        let txt = src.get_or_insert_text("notepad");
+        txt.insert(&mut src.transact_mut(), 0, "x");
+        let sv = src.transact().state_vector();
+        txt.insert(&mut src.transact_mut(), 1, "y");
+        let txn = src.transact();
+        txn.encode_state_as_update_v1(&sv)
+    }
+
+    #[test]
+    fn integrated_update_keeps_content_and_drops_pending_when_mixed() {
+        // The realistic case: a doc with real integrated content AND a pending
+        // struct. Pruning must keep the content and drop only the pending.
+        let (first, _dep) = gap_pair();
+        let doc = Doc::new();
+        doc.transact_mut()
+            .apply_update(yrs::Update::decode_v1(&first).unwrap())
+            .unwrap(); // integrated "a"
+        doc.transact_mut()
+            .apply_update(yrs::Update::decode_v1(&independent_gappy_insert()).unwrap())
+            .unwrap(); // + a pending struct from another client
+        assert!(has_pending(&doc));
+
+        let gap_free = integrated_update(&doc, &yrs::StateVector::default()).unwrap();
+        let peer = Doc::new();
+        peer.transact_mut()
+            .apply_update(yrs::Update::decode_v1(&gap_free).unwrap())
+            .unwrap();
+        assert_eq!(
+            peer.get_or_insert_text("notepad")
+                .get_string(&peer.transact()),
+            "a",
+            "kept the integrated content"
+        );
+        assert!(!has_pending(&peer), "dropped the pending");
+    }
+
+    #[test]
+    fn integrated_update_diffs_against_a_peer_sv_and_excludes_pending() {
+        // The production signature: `handle_sync_message` calls
+        // integrated_update(doc, peer_sv). A peer already holding the integrated
+        // content should get a diff carrying no new content and no pending.
+        let (first, _dep) = gap_pair();
+        let server = Doc::new();
+        server
+            .transact_mut()
+            .apply_update(yrs::Update::decode_v1(&first).unwrap())
+            .unwrap();
+        server
+            .transact_mut()
+            .apply_update(yrs::Update::decode_v1(&independent_gappy_insert()).unwrap())
+            .unwrap();
+
+        let peer = Doc::new();
+        peer.transact_mut()
+            .apply_update(yrs::Update::decode_v1(&first).unwrap())
+            .unwrap();
+        let peer_sv = peer.transact().state_vector();
+
+        let diff = integrated_update(&server, &peer_sv).unwrap();
+        peer.transact_mut()
+            .apply_update(yrs::Update::decode_v1(&diff).unwrap())
+            .unwrap();
+        assert_eq!(
+            peer.get_or_insert_text("notepad")
+                .get_string(&peer.transact()),
+            "a"
+        );
+        assert!(!has_pending(&peer), "the diff carried no pending");
+    }
+
+    #[test]
+    fn integrated_update_strips_a_pending_delete_set() {
+        // A deletion whose target struct is absent parks as a pending *delete
+        // set* -- the delete-side counterpart to a pending struct.
+        let src = Doc::new();
+        let txt = src.get_or_insert_text("notepad");
+        txt.insert(&mut src.transact_mut(), 0, "z");
+        let sv = src.transact().state_vector();
+        txt.remove_range(&mut src.transact_mut(), 0, 1);
+        let deletion = src.transact().encode_state_as_update_v1(&sv); // delete-only
+
+        let doc = Doc::new();
+        doc.transact_mut()
+            .apply_update(yrs::Update::decode_v1(&deletion).unwrap())
+            .unwrap();
+        assert!(
+            has_pending(&doc),
+            "the orphan deletion parked as a pending delete set"
+        );
+
+        let gap_free = integrated_update(&doc, &yrs::StateVector::default()).unwrap();
+        let peer = Doc::new();
+        peer.transact_mut()
+            .apply_update(yrs::Update::decode_v1(&gap_free).unwrap())
+            .unwrap();
+        assert!(!has_pending(&peer), "the pending delete set was not served");
+        assert!(has_pending(&doc), "non-destructive: source keeps its pending");
+    }
 }

--- a/ext/yrby/src/protocol.rs
+++ b/ext/yrby/src/protocol.rs
@@ -653,6 +653,9 @@ mod tests {
             .apply_update(yrs::Update::decode_v1(&gap_free).unwrap())
             .unwrap();
         assert!(!has_pending(&peer), "the pending delete set was not served");
-        assert!(has_pending(&doc), "non-destructive: source keeps its pending");
+        assert!(
+            has_pending(&doc),
+            "non-destructive: source keeps its pending"
+        );
     }
 }

--- a/lib/y/version.rb
+++ b/lib/y/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Y
-  VERSION = "0.2.3"
+  VERSION = "0.3.0"
 end

--- a/test/fixtures/generate_fixtures.mjs
+++ b/test/fixtures/generate_fixtures.mjs
@@ -72,6 +72,21 @@ const concurrentClients = (() => {
   })
 })()
 
+// Fixture 9: a causal gap as two separate deltas. FIRST inserts "a" (client 1);
+// DEPENDENT inserts "b" after it, so DEPENDENT depends on FIRST. Applied to a doc
+// that lacks FIRST, DEPENDENT parks as a pending struct (empty state vector, no
+// integrated content) -- the shape of legacy gappy data poisoning sync.
+const gap = (() => {
+  const updates = []
+  const doc = new Y.Doc()
+  doc.clientID = 1
+  doc.on("update", u => updates.push(u))
+  const t = doc.getText("notepad")
+  t.insert(0, "a")
+  t.insert(1, "b")
+  return { first: b64(updates[0]), dependent: b64(updates[1]) }
+})()
+
 // Fixture 8: a deletion delivered as its own delta. Insert "hello" (client 1),
 // snapshot that state, then delete the first char and capture the incremental
 // update. The deletion diff carries only a delete set (no new structs), so
@@ -191,6 +206,15 @@ module YjsFixtures
   module DeleteRetry
     CONTENT = YjsFixtures.b64("${deleteRetry.content}")
     DELETION = YjsFixtures.b64("${deleteRetry.deletion}")
+  end
+
+  # Fixture 9: a causal gap as two deltas. FIRST inserts "a" (client 1); DEPENDENT
+  # inserts "b" after it. Applied without FIRST, DEPENDENT parks as a pending
+  # struct (empty state vector, no integrated content) -- legacy gappy data that
+  # poisons sync if served. Healed by later applying FIRST.
+  module Gap
+    FIRST = YjsFixtures.b64("${gap.first}")
+    DEPENDENT = YjsFixtures.b64("${gap.dependent}")
   end
 end
 `

--- a/test/fixtures/generate_fixtures.mjs
+++ b/test/fixtures/generate_fixtures.mjs
@@ -84,7 +84,33 @@ const gap = (() => {
   const t = doc.getText("notepad")
   t.insert(0, "a")
   t.insert(1, "b")
-  return { first: b64(updates[0]), dependent: b64(updates[1]) }
+
+  // A second, independent gap from a DIFFERENT client (2): insert "x" then "y",
+  // keep only the "y" delta. Applied on top of client 1's integrated content it
+  // parks as pending *without* dropping the real content -- the mixed case.
+  const other = []
+  const d2 = new Y.Doc()
+  d2.clientID = 2
+  d2.on("update", u => other.push(u))
+  const t2 = d2.getText("notepad")
+  t2.insert(0, "x")
+  t2.insert(1, "y")
+
+  return { first: b64(updates[0]), dependent: b64(updates[1]), dependentOther: b64(other[1]) }
+})()
+
+// Fixture 10: a pending *delete set*. Client 3 inserts "z", then deletes it; we
+// keep only the deletion delta. Applied to a doc without client 3's content, the
+// delete set references a struct that isn't there, so it parks as a pending
+// delete set (the delete-side counterpart to a pending struct).
+const pendingDelete = (() => {
+  const doc = new Y.Doc()
+  doc.clientID = 3
+  const t = doc.getText("notepad")
+  t.insert(0, "z")
+  const sv = Y.encodeStateVector(doc)
+  t.delete(0, 1)
+  return b64(Y.encodeStateAsUpdate(doc, sv)) // deletion only
 })()
 
 // Fixture 8: a deletion delivered as its own delta. Insert "hello" (client 1),
@@ -215,6 +241,16 @@ module YjsFixtures
   module Gap
     FIRST = YjsFixtures.b64("${gap.first}")
     DEPENDENT = YjsFixtures.b64("${gap.dependent}")
+    # A gappy insert from a different client (2), for the "integrated content plus
+    # pending" mixed case (applied on top of FIRST's integrated "a").
+    DEPENDENT_OTHER = YjsFixtures.b64("${gap.dependentOther}")
+  end
+
+  # Fixture 10: a pending *delete set* -- a deletion delta whose target struct the
+  # doc doesn't have, so it parks as a pending delete set (delete-side counterpart
+  # to a pending struct). See DeleteRetry for a fully-integrated deletion.
+  module PendingDelete
+    UPDATE = YjsFixtures.b64("${pendingDelete}")
   end
 end
 `

--- a/test/fixtures/yjs_fixtures.rb
+++ b/test/fixtures/yjs_fixtures.rb
@@ -89,5 +89,15 @@ module YjsFixtures
   module Gap
     FIRST = YjsFixtures.b64("AQEBAAQBB25vdGVwYWQBYQA=")
     DEPENDENT = YjsFixtures.b64("AQEBAYQBAAFiAA==")
+    # A gappy insert from a different client (2), for the "integrated content plus
+    # pending" mixed case (applied on top of FIRST's integrated "a").
+    DEPENDENT_OTHER = YjsFixtures.b64("AQECAYQCAAF5AA==")
+  end
+
+  # Fixture 10: a pending *delete set* -- a deletion delta whose target struct the
+  # doc doesn't have, so it parks as a pending delete set (delete-side counterpart
+  # to a pending struct). See DeleteRetry for a fully-integrated deletion.
+  module PendingDelete
+    UPDATE = YjsFixtures.b64("AAEDAQAB")
   end
 end

--- a/test/fixtures/yjs_fixtures.rb
+++ b/test/fixtures/yjs_fixtures.rb
@@ -81,4 +81,13 @@ module YjsFixtures
     CONTENT = YjsFixtures.b64("AQEBAAQBB2NvbnRlbnQFaGVsbG8A")
     DELETION = YjsFixtures.b64("AAEBAQAB")
   end
+
+  # Fixture 9: a causal gap as two deltas. FIRST inserts "a" (client 1); DEPENDENT
+  # inserts "b" after it. Applied without FIRST, DEPENDENT parks as a pending
+  # struct (empty state vector, no integrated content) -- legacy gappy data that
+  # poisons sync if served. Healed by later applying FIRST.
+  module Gap
+    FIRST = YjsFixtures.b64("AQEBAAQBB25vdGVwYWQBYQA=")
+    DEPENDENT = YjsFixtures.b64("AQEBAYQBAAFiAA==")
+  end
 end

--- a/test/pending_test.rb
+++ b/test/pending_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "fixtures/yjs_fixtures"
+
+# Pending-struct handling and gap-free serving.
+#
+# A gappy update (one whose causally-prior update is missing) parks in yrs as a
+# *pending* struct: the doc's integrated state stays empty, but the pending block
+# is a recovery buffer that heals if the missing dependency later arrives.
+#
+# The danger is that `encode_state_as_update` merges pending back in, so serving
+# that state hands a peer content it can't integrate -- the peer parks the same
+# pending forever and the state-vector/content mismatch drives endless resync
+# traffic. So the sync path and `compacted_state_update` must serve integrated
+# state only, while `encode_state_as_update` stays lossless for raw recovery.
+class PendingTest < Minitest::Test
+  FIRST = YjsFixtures::Gap::FIRST
+  DEPENDENT = YjsFixtures::Gap::DEPENDENT
+
+  # --- detection ---
+
+  def test_clean_doc_is_not_pending
+    doc = Y::Doc.new
+    doc.apply_update(FIRST)
+
+    refute_predicate doc, :pending?
+  end
+
+  def test_gappy_update_parks_as_pending
+    doc = Y::Doc.new
+    doc.apply_update(DEPENDENT) # depends on the missing FIRST
+
+    assert_predicate doc, :pending?
+    assert_nil doc.read_text("notepad"), "no integrated content while pending"
+  end
+
+  def test_pending_clears_once_the_missing_dependency_arrives
+    doc = Y::Doc.new
+    doc.apply_update(DEPENDENT)
+    doc.apply_update(FIRST)
+
+    refute_predicate doc, :pending?, "gap healed"
+    assert_equal "ab", doc.read_text("notepad")
+  end
+
+  # --- compacted_state_update (gap-free full state) ---
+
+  def test_compacted_matches_full_encode_when_clean
+    doc = Y::Doc.new
+    doc.apply_update(FIRST)
+
+    assert_equal doc.encode_state_as_update, doc.compacted_state_update
+  end
+
+  def test_compacted_excludes_pending_while_encode_keeps_it
+    doc = Y::Doc.new
+    doc.apply_update(DEPENDENT)
+
+    full = doc.encode_state_as_update
+    compacted = doc.compacted_state_update
+
+    refute_equal full, compacted, "compacted drops the pending bytes"
+
+    # The lossless encode still round-trips the pending (recovery); the compacted
+    # one does not poison a fresh peer.
+    lossless_peer = Y::Doc.new
+    lossless_peer.apply_update(full)
+
+    assert_predicate lossless_peer, :pending?, "encode_state_as_update preserved the pending"
+
+    clean_peer = Y::Doc.new
+    clean_peer.apply_update(compacted)
+
+    refute_predicate clean_peer, :pending?, "compacted_state_update carried no pending"
+  end
+
+  def test_compacted_is_non_destructive
+    doc = Y::Doc.new
+    doc.apply_update(DEPENDENT)
+    doc.compacted_state_update
+
+    assert_predicate doc, :pending?, "compacting did not mutate the source doc"
+  end
+
+  def test_compacted_serves_content_once_healed
+    doc = Y::Doc.new
+    doc.apply_update(DEPENDENT)
+    doc.apply_update(FIRST)
+
+    peer = Y::Doc.new
+    peer.apply_update(doc.compacted_state_update)
+
+    assert_equal "ab", peer.read_text("notepad")
+  end
+
+  # --- the sync path serves gap-free by default ---
+
+  def test_sync_step2_reply_does_not_poison_a_peer
+    # A server whose stored state contains a legacy gappy update.
+    server = Y::Doc.new
+    server.apply_update(DEPENDENT)
+
+    # A fresh client announces its (empty) state; the server answers SyncStep2.
+    client = Y::Doc.new
+    reply = server.handle_sync_message(client.sync_step1)[2]
+    client.handle_sync_message(reply)
+
+    refute_predicate client, :pending?, "the server served integrated-only state, no poison"
+  end
+
+  def test_sync_step2_still_delivers_real_content
+    server = Y::Doc.new
+    server.apply_update(YjsFixtures::TextHelloWorld::UPDATE)
+
+    client = Y::Doc.new
+    reply = server.handle_sync_message(client.sync_step1)[2]
+    client.handle_sync_message(reply)
+
+    assert_equal "hello world", client.read_text("content")
+  end
+end

--- a/test/pending_test.rb
+++ b/test/pending_test.rb
@@ -17,6 +17,8 @@ require_relative "fixtures/yjs_fixtures"
 class PendingTest < Minitest::Test
   FIRST = YjsFixtures::Gap::FIRST
   DEPENDENT = YjsFixtures::Gap::DEPENDENT
+  DEPENDENT_OTHER = YjsFixtures::Gap::DEPENDENT_OTHER
+  PENDING_DELETE = YjsFixtures::PendingDelete::UPDATE
 
   # --- detection ---
 
@@ -118,5 +120,89 @@ class PendingTest < Minitest::Test
     client.handle_sync_message(reply)
 
     assert_equal "hello world", client.read_text("content")
+  end
+
+  # --- mixed: real integrated content AND a pending struct together ---
+
+  def test_compacted_keeps_content_and_drops_pending_when_mixed
+    doc = Y::Doc.new
+    doc.apply_update(FIRST)           # integrated "a"
+    doc.apply_update(DEPENDENT_OTHER) # + a pending struct from another client
+
+    assert_predicate doc, :pending?
+    assert_equal "a", doc.read_text("notepad"), "only the integrated content is visible"
+
+    peer = Y::Doc.new
+    peer.apply_update(doc.compacted_state_update)
+
+    assert_equal "a", peer.read_text("notepad"), "kept the real content"
+    refute_predicate peer, :pending?, "dropped the pending"
+  end
+
+  def test_sync_diff_to_an_up_to_date_peer_excludes_pending
+    # The production path: server has integrated content + pending; a peer that
+    # already has the content asks for a diff (its own state vector).
+    server = Y::Doc.new
+    server.apply_update(FIRST)
+    server.apply_update(DEPENDENT_OTHER)
+
+    peer = Y::Doc.new
+    peer.apply_update(FIRST) # already up to date on integrated state
+    reply = server.handle_sync_message(peer.sync_step1)[2]
+    peer.handle_sync_message(reply)
+
+    assert_equal "a", peer.read_text("notepad")
+    refute_predicate peer, :pending?, "the diff carried no pending"
+  end
+
+  # --- pending delete set (delete-side counterpart) ---
+
+  def test_pending_delete_set_is_detected_and_not_served
+    doc = Y::Doc.new
+    doc.apply_update(PENDING_DELETE) # a deletion whose target struct is absent
+
+    assert_predicate doc, :pending?, "an orphan deletion parks as a pending delete set"
+
+    peer = Y::Doc.new
+    peer.apply_update(doc.compacted_state_update)
+
+    refute_predicate peer, :pending?, "the pending delete set was not served"
+    assert_predicate doc, :pending?, "non-destructive: source keeps its pending"
+  end
+
+  def test_sync_step2_does_not_serve_a_pending_delete_set
+    server = Y::Doc.new
+    server.apply_update(PENDING_DELETE)
+
+    client = Y::Doc.new
+    reply = server.handle_sync_message(client.sync_step1)[2]
+    client.handle_sync_message(reply)
+
+    refute_predicate client, :pending?
+  end
+
+  # --- thread safety of the new readers (match the nogvl model) ---
+
+  def test_pending_and_compacted_are_thread_safe_under_contention
+    doc = Y::Doc.new
+    doc.apply_update(FIRST)
+    doc.apply_update(DEPENDENT_OTHER) # holds pending, so the slow prune path runs
+    errors = Queue.new
+
+    threads = 8.times.map do
+      Thread.new do
+        50.times do
+          doc.pending?
+          doc.compacted_state_update
+          doc.encode_state_as_update
+        end
+      rescue StandardError => e
+        errors << e
+      end
+    end
+    threads.each(&:join)
+
+    assert_empty([].tap { |a| a << errors.pop until errors.empty? })
+    assert_predicate doc, :pending?, "reads left the doc unchanged"
   end
 end

--- a/test/sync_test.rb
+++ b/test/sync_test.rb
@@ -135,6 +135,23 @@ class SyncTest < Minitest::Test
     assert_equal source.encode_state_vector, rebuilt.encode_state_vector
   end
 
+  def test_sync_step1_is_answered_with_gap_free_state_from_the_store
+    # A store holding a legacy gappy update: the loaded doc has a pending struct.
+    # The concern must answer SyncStep1 with integrated-only state, so a client
+    # applying the reply is not poisoned.
+    transmits = []
+    helper = helper_for(store: [YjsFixtures::Gap::DEPENDENT], transmits: transmits)
+
+    client = Y::Doc.new
+    helper.sync_receive({ "update" => Base64.strict_encode64(client.sync_step1) }, "doc-key")
+
+    assert_equal 1, transmits.length
+    reply = Base64.strict_decode64(transmits.first["update"])
+    client.handle_sync_message(reply)
+
+    refute_predicate client, :pending?, "the concern served integrated-only state"
+  end
+
   def test_records_then_relays_and_acks_update
     store = []
     recorded = []


### PR DESCRIPTION
Deliverable 1 of the gap-free-sync plan. Fixes the endless-resync poison from legacy pending structs, and exposes the supporting primitives.

## The bug

A **pending** struct (a gappy update whose causally-prior update is missing — e.g. data recorded before the `update_ready?` gate existed) has an **empty** integrated state vector, but `encode_state_as_update` merges the pending bytes back in (yrs `merge_pending_v1`). So answering a peer's `SyncStep1` handed it content it couldn't integrate → the peer parked the same pending forever, and the empty-SV / non-empty-content mismatch drove endless resync traffic (a browser re-sending frames ~several times/sec).

Verified with the exact repro (server holds a gappy update → fresh client syncs → client ends up `pending?`, empty, looping).

## The fix

`handle_sync_message` now answers `SyncStep1` with **integrated-only** state. The enabling primitive is yrs's public `WriteTxn::prune_pending` (takes the pending out and returns it) — so no upstream patch, no Snapshot/GC fragility. We rebuild state into a throwaway doc, prune it, and re-encode; the **live doc is never mutated**, and a fast path skips the rebuild entirely when nothing is pending (clean case stays zero-copy).

- **Neutralizes existing poisoned server state on deploy — no migration.**
- The server's own pending is untouched and still **heals** if the missing dependency later arrives (only then does the content become visible in sync).
- Live delta relay (`Update` frames) is unchanged.

## New primitives

- `Doc#pending?` — holds un-integrable pending structs / delete set?
- `Doc#compacted_state_update` — full state, **gap-free**, non-destructive. For when you persist/serve state yourself. `encode_state_as_update` stays **lossless** for raw-update recovery.

## Tests

- **Rust**: `has_pending` / `integrated_update` — strips pending, non-destructive (source keeps pending), fast-path byte-identical to direct encode when clean, heals after the dep arrives.
- **Ruby** (`pending_test.rb`): detection + heal; compacted excludes pending while `encode_state_as_update` keeps it; **the exact server-store poison repro** proving the `SyncStep2` reply no longer poisons a peer; SyncStep2 still delivers real content.
- New real-Y.js `Gap` fixture added to `generate_fixtures.mjs` (all other fixtures regenerate byte-identically).
- Full suite green: 86 Ruby runs, 20 Rust tests, clippy + rustfmt + rubocop clean.

Bumps **yrby 0.2.3 → 0.3.0**.

> **Coordination:** live-maps #33 is also `0.3.0`. Whichever merges first keeps `0.3.0`; the other rebases to `0.4.0`. Deliverable 2 (yrby-actioncable delivery defense / retry-cap) is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)