### PR TITLE
yrby-actioncable 0.2.3: raise yrby floor to >= 0.3.0

### DIFF
--- a/CHANGELOG-actioncable.md
+++ b/CHANGELOG-actioncable.md
@@ -6,6 +6,18 @@ this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-07-01
+
+### Changed
+- Raised the `yrby` floor to `>= 0.3.0`. That release makes
+  `Doc#handle_sync_message` answer `SyncStep1` with integrated-only (gap-free)
+  state — it no longer serves un-integrable pending structs, which previously
+  poisoned peers and drove endless resync traffic. The sync channel serves its
+  SyncStep2 response through that method, so with an older core a poisoned server
+  store would still hand the gap to clients. No code change here — pinning the
+  floor makes gap-free serving self-enforcing instead of dependent on the app
+  updating the core gem.
+
 ## [0.2.2] - 2026-07-01
 
 ### Changed

--- a/lib/y/action_cable/version.rb
+++ b/lib/y/action_cable/version.rb
@@ -2,6 +2,6 @@
 
 module Y
   module ActionCable
-    VERSION = "0.2.2"
+    VERSION = "0.2.3"
   end
 end

--- a/yrby-actioncable.gemspec
+++ b/yrby-actioncable.gemspec
@@ -33,10 +33,12 @@ Gem::Specification.new do |spec|
   spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.add_dependency "base64", "~> 0.2"
-  # Floor raised to 0.2.3, whose update_advances? is exact for delete-bearing
-  # updates -- the channel gates durable record-before-distribute on it, so the
-  # floor makes the exactly-once guarantee self-enforcing (not app-dependent).
-  spec.add_dependency "yrby", ">= 0.2.3"
+  # Floor raised to 0.3.0, whose handle_sync_message answers SyncStep1 with
+  # integrated-only (gap-free) state. The channel serves the sync response through
+  # that method, so the floor makes gap-free serving self-enforcing rather than
+  # dependent on the app updating the core gem. (0.2.3 similarly made
+  # update_advances? exact for delete-bearing updates.)
+  spec.add_dependency "yrby", ">= 0.3.0"
   # The concern references ActionCable (channels, streaming, broadcasting) and
   # ActiveSupport (Concern, JSON coder) constants directly. Rails apps already
   # bundle these, but declaring them makes use outside a full Rails bundle fail


### PR DESCRIPTION
Bumps **yrby-actioncable 0.2.2 → 0.2.3**, raising the `yrby` floor `>= 0.2.3` → `>= 0.3.0`. No code change.

## Why

The channel serves its `SyncStep2` response through `Doc#handle_sync_message` (`sync.rb:256`). yrby 0.3.0 makes that answer **integrated-only (gap-free)** — it no longer serves un-integrable pending structs, which previously poisoned peers and drove endless resync traffic. With the floor at `>= 0.2.3`, a poisoned server store could still hand the gap to clients if the app hadn't updated core.

Raising the floor to `>= 0.3.0` makes gap-free serving **self-enforcing**. Pure-Ruby, single gem, no precompilation. Built gem's dependency confirmed: `yrby >= 0.3.0`.

Follows the same precedent as 0.2.2 (floor `>= 0.2.3` for the `update_advances?` fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)