### PR TITLE
Release automation: tag → GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+# Turns a pushed version tag into a GitHub release, with notes pulled from the
+# matching CHANGELOG section. Tag scheme (packages are versioned independently):
+#
+#   v1.2.3                      core gem (yrby)          -> CHANGELOG.md
+#   yrby-rails-v1.2.3           rails gem                -> CHANGELOG-rails.md
+#   yrby-client-v1.2.3          npm client               -> generated notes
+#
+# Publishing the packages themselves (RubyGems/npm) is still manual; this only
+# creates the release. See `rake release:steps`.
+
+on:
+  push:
+    tags:
+      - "v*"
+      - "yrby-rails-v*"
+      - "yrby-client-v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Create the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          case "$TAG" in
+            yrby-rails-v*) pkg="yrby-rails"; ver="${TAG#yrby-rails-v}"; changelog="CHANGELOG-rails.md" ;;
+            yrby-client-v*)      pkg="yrby-client";      ver="${TAG#yrby-client-v}";      changelog="" ;;
+            v*)                  pkg="yrby";             ver="${TAG#v}";                  changelog="CHANGELOG.md" ;;
+            *) echo "::error::unrecognized tag '$TAG'"; exit 1 ;;
+          esac
+
+          notes="$(mktemp)"
+          if [ -n "$changelog" ] && [ -f "$changelog" ]; then
+            # Grab the "## [ver]" section up to the next "## " header.
+            awk -v ver="$ver" '
+              $0 ~ "^## \\[" ver "\\]" { grab = 1; next }
+              grab && /^## / { exit }
+              grab { print }
+            ' "$changelog" > "$notes"
+          fi
+
+          # Mark pre-1.0 pre-releases (beta/alpha/rc) as such.
+          prerelease=""
+          case "$ver" in *beta*|*alpha*|*rc*) prerelease="--prerelease" ;; esac
+
+          if [ -s "$notes" ]; then
+            gh release create "$TAG" --title "$pkg $ver" --notes-file "$notes" $prerelease
+          else
+            echo "No changelog section for $pkg $ver; using generated notes."
+            gh release create "$TAG" --title "$pkg $ver" --generate-notes $prerelease
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,12 @@ jobs:
 
           if [ -s "$notes" ]; then
             gh release create "$TAG" --title "$pkg $ver" --notes-file "$notes" $prerelease
+          elif [ -n "$changelog" ]; then
+            # A package with a changelog and no section for this version means
+            # the release prep is incomplete (usually [Unreleased] never got
+            # renamed). Fail rather than ship a commit list as the notes.
+            echo "::error::$changelog has no '## [$ver]' section for $pkg $ver"
+            exit 1
           else
-            echo "No changelog section for $pkg $ver; using generated notes."
             gh release create "$TAG" --title "$pkg $ver" --generate-notes $prerelease
           fi

--- a/Rakefile
+++ b/Rakefile
@@ -62,7 +62,7 @@ namespace :release do
          b. git tag yrby-client-v#{npm} && git push origin "yrby-client-v#{npm}"
          c. cd packages/client && npm publish
 
-      The actioncable gem pins a minimum `yrby` (a floor, so it tolerates
+      The rails gem pins a minimum `yrby` (a floor, so it tolerates
       newer core releases); only raise it when it needs a newer core API.
     STEPS
   end

--- a/Rakefile
+++ b/Rakefile
@@ -38,21 +38,29 @@ namespace :release do
       two gems together when the shared core API changes. JP runs the push steps
       (RubyGems MFA, npm auth, and the default-branch guard).
 
+      Each package has its own tag, and pushing the tag triggers the Release
+      workflow, which creates the GitHub release from the CHANGELOG. Core keeps
+      the bare `v` tags (the precompiled-gems workflow already runs on `v*`);
+      the companions are prefixed so the versions don't collide.
+
       1) yrby #{core}  — core gem, native extension; precompiled platform gems via CI
          a. bump lib/y/version.rb + CHANGELOG.md, then commit
          b. git tag v#{core} && git push origin main "v#{core}"
-         c. the "Precompiled gems" workflow builds 8 platform gems + the source gem
+         c. the "Precompiled gems" workflow builds 8 platform gems + the source gem;
+            the Release workflow creates the GitHub release
          d. gh run download <run-id> --dir tmp/ ; cp tmp/**/*.gem pkg/
          e. for g in pkg/yrby-#{core}*.gem; do gem push "$g" || break; done   # 9 gems (gem push takes ONE at a time)
 
       2) yrby-rails #{cable}  — gem, pure Ruby; one gem, no precompilation
          a. bump lib/yrby/rails/version.rb + CHANGELOG-rails.md, commit
-         b. rake rails_gem:build
-         c. gem push pkg/yrby-rails-#{cable}.gem
+         b. git tag yrby-rails-v#{cable} && git push origin "yrby-rails-v#{cable}"
+         c. rake rails_gem:build
+         d. gem push pkg/yrby-rails-#{cable}.gem
 
       3) yrby-client #{npm}  — npm package (client SDK: provider + sync engine + reliable delivery)
          a. bump packages/client/package.json version, commit
-         b. cd packages/client && npm publish
+         b. git tag yrby-client-v#{npm} && git push origin "yrby-client-v#{npm}"
+         c. cd packages/client && npm publish
 
       The actioncable gem pins a minimum `yrby` (a floor, so it tolerates
       newer core releases); only raise it when it needs a newer core API.


### PR DESCRIPTION
Adds a workflow that creates a git tag and GitHub release for every published version.

The project publishes three independently-versioned packages. Releases and companion tags were created by hand for the current versions; everything before them has neither.

| Package | Published | Tags | Releases |
|---|---|---|---|
| `yrby` (core gem) | through 0.6.1 | `v0.1.0.beta1`…`v0.6.1` (19) | `v0.6.1` only |
| `yrby-rails` | 0.4.0, 0.5.0 | `yrby-rails-v0.5.0` | `yrby-rails v0.5.0` |
| `yrby-client` (npm) | through 0.5.0 | `yrby-client-v0.5.0` | `yrby-client v0.5.0` |

The bare `vX.Y.Z` tags are also ambiguous in a monorepo: `v0.2.2` is tagged and changelogged but core 0.2.2 was never published (folded into 0.2.3).

`release.yml` fires on a version tag, pulls that version's section from the right CHANGELOG, and creates the GitHub release. Core stays bare (it has working tags and the precompiled-gems CI already triggers on `v*`); companions are prefixed so versions don't collide:

- `v1.2.3` → core → `CHANGELOG.md`
- `yrby-rails-v1.2.3` → `CHANGELOG-rails.md`
- `yrby-client-v1.2.3` → generated notes (the npm client has no changelog)

That prefix scheme is the one the existing companion tags already use, so the workflow takes over from the manual process without renaming anything.

`rake release:steps` now includes the tag step for each package. Publishing to RubyGems and npm stays manual.

Backfilling releases for already-published versions is not included. Core tags exist, so those releases would be one command each; the companion versions before 0.5.0 have no tags, so backfilling them means creating tags at reconstructed historical commits.
