### PR TITLE
README: ephemeral documents without a database

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,10 +658,31 @@ can be connection state that travels with each request:
 
 ```ruby
 class ScratchpadChannel < ApplicationCable::Channel
-  include Y::ActionCable::Sync
+  include Y::ActionCable
 
-  # From anycable-rails. On AnyCable the value rides every RPC round trip;
-  # on Action Cable it's an ordinary accessor on the long-lived channel.
+  on_load { |key| @doc_state }
+
+  on_change do |key, update|
+    doc = Y::Doc.new
+    doc.apply_update(@doc_state) if @doc_state
+    doc.apply_update(update)
+    @doc_state = doc.compacted_state_update
+  end
+
+  def subscribed    = sync_subscribed(params[:id])
+  def receive(data) = sync_receive(data, params[:id])
+end
+```
+
+On AnyCable the channel object doesn't survive between messages, so an
+instance variable won't hold. Declare the store as channel state instead
+(`state_attr_accessor` comes from anycable-rails) and Base64 it, because that
+state is serialized as JSON into each RPC exchange with `anycable-go`:
+
+```ruby
+class ScratchpadChannel < ApplicationCable::Channel
+  include Y::ActionCable
+
   state_attr_accessor :doc_state
 
   on_load { |key| doc_state && Base64.strict_decode64(doc_state) }
@@ -679,13 +700,10 @@ end
 ```
 
 Both hooks run in the channel instance (`instance_exec`), so they can use
-anything the channel can. `state_attr_accessor` is what makes this work on
-AnyCable: channel objects there don't persist between messages, but declared
-state is serialized into each RPC exchange with `anycable-go`, so the store
-follows the client no matter which RPC worker handles the next message. On
-plain Action Cable the channel instance lives as long as the connection, and
-the same accessor is just an instance variable. The Base64 wrapping is because
-AnyCable state must serialize as JSON; the merge into
+anything the channel can, and `sync_receive` rebuilds the document from
+`on_load` on every update, which is what lets the store live on the
+connection. On Action Cable the channel instance lasts as long as the
+connection, so an instance variable is the whole store. Merging into
 `compacted_state_update` keeps it one blob instead of a growing update log.
 
 The store is per connection, which shapes what this fits. A single writer gets
@@ -694,9 +712,9 @@ editing at once, one client's update can depend on another client's edits that
 its own connection state has never seen; the gap check refuses the update and
 starts a resync, and the client, which always holds the full document,
 sends the missing state back. The document still converges, but heavy
-concurrent editing pays resync round trips that a shared store doesn't. Keep
-the payload in mind too: on AnyCable the blob travels with every message, so
-this suits small documents, not long manuscripts.
+concurrent editing pays resync round trips that a shared store doesn't. On
+AnyCable, keep the payload in mind too: the blob travels with every message,
+so that variant suits small documents, not long manuscripts.
 
 Durability is the connection plus the browsers. A reconnecting client re-seeds
 an empty server through the ordinary sync handshake, so the document survives

--- a/README.md
+++ b/README.md
@@ -653,8 +653,8 @@ end to end that the log alone rebuilds the document.
 #### Ephemeral documents (no database)
 
 `on_load` and `on_change` are plain blocks, and nothing requires them to touch
-a database. For documents that don't need to outlive their session — a
-scratchpad, live form state, a draft you only persist on submit — the store
+a database. For documents that don't need to outlive their session (a
+scratchpad, live form state, a draft you only persist on submit) the store
 can be connection state that travels with each request:
 
 ```ruby
@@ -693,7 +693,7 @@ The store is per connection, which shapes what this fits. A single writer gets
 the full delivery contract with no database anywhere. With several people
 editing at once, one client's update can depend on another client's edits that
 its own connection state has never seen; the gap check refuses the update and
-starts a resync, and the client — which always holds the full document —
+starts a resync, and the client, which always holds the full document,
 sends the missing state back. The document still converges, but heavy
 concurrent editing pays resync round trips that a shared store doesn't. Keep
 the payload in mind too: on AnyCable the blob travels with every message, so

--- a/README.md
+++ b/README.md
@@ -650,6 +650,62 @@ duplicate record replays to the same document.
 The demo wires `on_change` to a durable Postgres-backed log by default, and checks
 end to end that the log alone rebuilds the document.
 
+#### Ephemeral documents (no database)
+
+`on_load` and `on_change` are plain blocks, and nothing requires them to touch
+a database. For documents that don't need to outlive their session — a
+scratchpad, live form state, a draft you only persist on submit — the store
+can be connection state that travels with each request:
+
+```ruby
+class ScratchpadChannel < ApplicationCable::Channel
+  include Y::ActionCable::Sync
+
+  # From anycable-rails. On AnyCable the value rides every RPC round trip;
+  # on Action Cable it's an ordinary accessor on the long-lived channel.
+  state_attr_accessor :doc_state
+
+  on_load { |key| doc_state && Base64.strict_decode64(doc_state) }
+
+  on_change do |key, update|
+    doc = Y::Doc.new
+    doc.apply_update(Base64.strict_decode64(doc_state)) if doc_state
+    doc.apply_update(update)
+    self.doc_state = Base64.strict_encode64(doc.compacted_state_update)
+  end
+
+  def subscribed    = sync_subscribed(params[:id])
+  def receive(data) = sync_receive(data, params[:id])
+end
+```
+
+Both hooks run in the channel instance (`instance_exec`), so they can use
+anything the channel can. `state_attr_accessor` is what makes this work on
+AnyCable: channel objects there don't persist between messages, but declared
+state is serialized into each RPC exchange with `anycable-go`, so the store
+follows the client no matter which RPC worker handles the next message. On
+plain Action Cable the channel instance lives as long as the connection, and
+the same accessor is just an instance variable. The Base64 wrapping is because
+AnyCable state must serialize as JSON; the merge into
+`compacted_state_update` keeps it one blob instead of a growing update log.
+
+The store is per connection, which shapes what this fits. A single writer gets
+the full delivery contract with no database anywhere. With several people
+editing at once, one client's update can depend on another client's edits that
+its own connection state has never seen; the gap check refuses the update and
+starts a resync, and the client — which always holds the full document —
+sends the missing state back. The document still converges, but heavy
+concurrent editing pays resync round trips that a shared store doesn't. Keep
+the payload in mind too: on AnyCable the blob travels with every message, so
+this suits small documents, not long manuscripts.
+
+Durability is the connection plus the browsers. A reconnecting client re-seeds
+an empty server through the ordinary sync handshake, so the document survives
+server restarts as long as some client still has it. For ephemeral documents
+shared across clients on a single-process deployment, the same two hooks over
+a class-level `Concurrent::Map` work instead; that version stops being
+coherent the moment you scale past one process.
+
 #### Reliable delivery (acks)
 
 yrby document delivery is ack-tracked. Browser document updates carry an


### PR DESCRIPTION
Adds an "Ephemeral documents (no database)" section to the README, under the ActionCable integration docs after Record Before Distribute.

`on_load` and `on_change` are plain blocks, so the store can be connection state instead of a database. The example channel keeps the compacted document in `state_attr_accessor` state: on AnyCable it rides every RPC exchange through anycable-go, so it follows the client across RPC workers; on Action Cable it's an ivar on the long-lived channel instance. It's base64-wrapped because AnyCable state serializes as JSON.

It works because both hooks run `instance_exec` in the channel instance (`lib/y/action_cable/sync.rb`), so channel state is reachable from them, and `sync_receive` rebuilds the document from `on_load` on every update, which is what lets the store travel with the request.

The section documents the trade-offs: per-connection scope (single-writer documents get the full delivery contract with no database; concurrent cross-client editing converges through gap-check resyncs), payload size (the blob travels with every AnyCable message, so this fits small documents), durability (reconnecting clients re-seed an empty server through the normal handshake), and the single-process `Concurrent::Map` alternative with its scale-out limit.
