### PR TITLE
README: intro that covers the full scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,42 @@
 
 [![CI](https://github.com/jpcamara/yrby/actions/workflows/ci.yml/badge.svg)](https://github.com/jpcamara/yrby/actions/workflows/ci.yml)
 
-Collaborative editing for Rails, backed by [y-crdt](https://github.com/y-crdt/y-crdt)
-(the Rust library behind Y.js). Your Rails server speaks the y-websocket sync
-protocol directly, so there's no separate Node process hosting the Y.js
-documents. Pronounced "yer-bee".
+yrby (pronounced "yer-bee") makes Rails a real Yjs backend. It binds
+[y-crdt](https://github.com/y-crdt/y-crdt), the Rust engine behind Y.js, into
+Ruby, and builds the rest of the stack around it: a sync server for Action
+Cable and AnyCable, a browser provider, and server-side reading and rendering
+of the documents. Real-time collaboration in a Rails app with no Node process
+anywhere in the path.
 
 ![Two people typing on separate lines of the same document, each keystroke synced through a Rails server, seen from a third browser with labeled carets](docs/images/collab.gif)
+
+On the server, `yrby-actioncable` implements the full y-websocket protocol
+(document sync plus presence) as a channel concern. Its delivery contract is
+stricter than the usual Yjs servers: every update is ack-tracked, checked for
+causal gaps, and durably recorded before it is acknowledged or broadcast to
+anyone. Replaying your store always rebuilds the document, across any number
+of processes. ([Delivery guarantees](#delivery-guarantees))
+
+In the browser, `yrby-client`'s `ActionCableProvider` connects anything that
+speaks Yjs. The demo app runs four rich text editors, and CI drives each one
+in real Chrome: Tiptap, [Lexxy](https://www.npmjs.com/package/lexxy-realtime),
+Rhino Editor, and CodeMirror. The same channel also syncs Yjs shapes with no
+editor at all: a whiteboard on a `Y.Map`, a kanban board on a `Y.Array`, a
+co-filled form. ([Editors](#editors))
+
+In Ruby, the documents are readable without a browser. `Doc#read_text` and
+`Doc#read_map` reconstruct contents for search, validation, and exports.
+`Y::Tiptap` and `Y::Lexxy` render a document to HTML byte-identical to the
+editor's own serializer, take rules for your app's custom nodes, and drop
+straight into ActionText. ([Rendering to HTML](#rendering-to-html))
+
+Underneath, the core is built for a production Rails deployment. A `Doc` is
+thread-safe across Puma and ActionCable threads. Native CRDT work runs with
+the GVL released, so it parallelizes on MRI. Incoming frames are validated
+before anything processes them, and multi-process and AnyCable setups are
+tested end to end. ([Thread Safety](#thread-safety))
+
+The whole server side of a collaborative document is one channel:
 
 ```ruby
 class DocumentChannel < ApplicationCable::Channel
@@ -21,31 +51,12 @@ class DocumentChannel < ApplicationCable::Channel
 end
 ```
 
-On the browser, use the `ActionCableProvider` from the 
-[`yrby-client`](https://www.npmjs.com/package/yrby-client) npm package.
-Integrates with any editor that includes Y.js support, such as Tiptap, ProseMirror
-and [Lexxy](https://www.npmjs.com/package/lexxy-realtime).
-
-## Usage
-
-Install the gem and npm package:
+Install the gem and the npm package:
 
 ```
 gem install yrby-actioncable # depends on yrby
 npm install yrby-client
 ```
-
-## What you get
-
-- A thread-safe Ruby `Doc` you can share across Ruby threads/fibers, and native CRDT work
-  runs with the GVL released.
-- The y-websocket protocol (document sync plus awareness/presence) as a
-  one-include ActionCable concern.
-- Authoritative record-before-distribute semantics: each document change can be
-  recorded durably before it goes out to anyone.
-- Optional server-side reads: `Doc#read_text` and `Doc#read_map` reconstruct a
-  document's contents in Ruby - no Node process - for search, exports, validation,
-  or server-side rendering.
 
 ## Scope
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ anywhere in the path.
 
 ![Two people typing on separate lines of the same document, each keystroke synced through a Rails server, seen from a third browser with labeled carets](docs/images/collab.gif)
 
-On the server, `yrby-actioncable` implements the full y-websocket protocol
+On the server, `yrby-rails` implements the full y-websocket protocol
 (document sync plus presence) as a channel concern. Its delivery contract is
 stricter than the usual Yjs servers: every update is ack-tracked, checked for
 causal gaps, and durably recorded before it is acknowledged or broadcast to
@@ -54,7 +54,7 @@ end
 Install the gem and the npm package:
 
 ```
-gem install yrby-actioncable # depends on yrby
+gem install yrby-rails # depends on yrby
 npm install yrby-client
 ```
 
@@ -75,7 +75,7 @@ guarantees, correctness, and thread safety.
 Towards that goal, `yrby` adds opinionated defaults on top of normal Yjs syncing:
 
 - Built-in update acknowledgement: the `ActionCableProvider` in `yrby-client` will continue to
-  send updates until an ack is received from the server. [`yrby-actioncable`](https://rubygems.org/gems/yrby-actioncable)
+  send updates until an ack is received from the server. [`yrby-rails`](https://rubygems.org/gems/yrby-rails)
   only sends an ack when applying an update is successful. The goal is at-least-once delivery,
   and because CRDTs are idempotent a duplicate update is effectively a no-op.
 - Gap detection in document updates: before applying an update and sending an ack to the client,


### PR DESCRIPTION
Rewrites the README intro so it covers the full scope of the project, not just the core sync server.

The old intro described yrby as a y-crdt binding that lets Rails speak the y-websocket protocol. The project is larger than that now, and the intro didn't mention the browser provider, server-side reading and rendering, the delivery guarantees, or the thread-safety work.

The new intro walks the stack, each paragraph linking to the relevant section:

- the `yrby-rails` sync server and its delivery contract (ack-tracked, gap-checked, recorded before broadcast);
- the `yrby-client` browser provider and the editors CI drives in real Chrome (Tiptap, Lexxy, Rhino, CodeMirror), plus editor-less Yjs shapes (a whiteboard on a `Y.Map`, a kanban board on a `Y.Array`, a co-filled form);
- server-side reading and HTML rendering (`Doc#read_text`/`read_map`, `Y::Tiptap`/`Y::Lexxy`);
- the production concerns underneath (thread-safe `Doc`, GVL released for native CRDT work, frame validation, multi-process and AnyCable tested end to end).

README only.