### PR TITLE
Y::Lexxy: emit the stored attachment tag, not a hardcoded one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project aims
 to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `Y::Lexxy` emits the attachment tag the node was created with instead of
+  a hardcoded `<action-text-attachment>`. Lexxy makes the tag configurable
+  (`Lexxy.configure`'s `attachmentTagName`, paired with
+  `ActionText::Attachment.tag_name` in Rails), and each attachment node
+  stores its tag, so a custom-tag app's rendered HTML now matches its
+  editor. A stored value that doesn't look like a tag name falls back to
+  the default; documents from before the tag was stored render unchanged.
+
 ## [0.6.0] - 2026-07-11
 
 ### Added

--- a/lib/y/lexxy.rb
+++ b/lib/y/lexxy.rb
@@ -52,24 +52,37 @@ module Y
     # and presence mirror Lexxy's exportDOM (nulls omitted, `previewable`
     # only when true, `presentation="gallery"` always).
     def self.upload(node)
-      out = +"<action-text-attachment"
+      tag = attachment_tag(node)
+      out = +"<#{tag}"
       out << attachment_attr(node, "sgid", "sgid")
       out << %( previewable="true") if node.attrs["previewable"] == true
       [%w[url src], %w[alt altText], %w[caption caption],
        %w[content-type contentType], %w[filename fileName],
        %w[filesize fileSize], %w[width width], %w[height height]]
         .each { |html_name, stored| out << attachment_attr(node, html_name, stored) }
-      %(#{out} presentation="gallery"></action-text-attachment>)
+      %(#{out} presentation="gallery"></#{tag}>)
     end
 
     # A content attachment (mention, embed): `content` carries the escaped
     # inner HTML; `plainText` is not exported.
     def self.mention(node)
-      out = +"<action-text-attachment"
+      tag = attachment_tag(node)
+      out = +"<#{tag}"
       out << attachment_attr(node, "sgid", "sgid")
       out << attachment_attr(node, "content", "innerHtml")
       out << attachment_attr(node, "content-type", "contentType")
-      "#{out}></action-text-attachment>"
+      "#{out}></#{tag}>"
+    end
+
+    # Lexxy's attachment tag is configurable (`Lexxy.configure`'s
+    # attachmentTagName, paired with ActionText::Attachment.tag_name on the
+    # Rails side), and each attachment node stores the tag it was created
+    # with. Emit the stored tag. The value is stored document data, not
+    # markup, so anything that doesn't look like a tag name falls back to
+    # ActionText's default.
+    def self.attachment_tag(node)
+      tag = node.attrs["tagName"].to_s
+      tag.match?(/\A[a-zA-Z][a-zA-Z0-9-]*\z/) ? tag : "action-text-attachment"
     end
 
     # A stored nil (unset) is skipped; a stored empty string still emits.

--- a/lib/y/lexxy.rb
+++ b/lib/y/lexxy.rb
@@ -53,7 +53,7 @@ module Y
     # only when true, `presentation="gallery"` always).
     def self.upload(node)
       tag = attachment_tag(node)
-      out = +"<#{tag}"
+      out = "<#{tag}"
       out << attachment_attr(node, "sgid", "sgid")
       out << %( previewable="true") if node.attrs["previewable"] == true
       [%w[url src], %w[alt altText], %w[caption caption],
@@ -67,7 +67,7 @@ module Y
     # inner HTML; `plainText` is not exported.
     def self.mention(node)
       tag = attachment_tag(node)
-      out = +"<#{tag}"
+      out = "<#{tag}"
       out << attachment_attr(node, "sgid", "sgid")
       out << attachment_attr(node, "content", "innerHtml")
       out << attachment_attr(node, "content-type", "contentType")

--- a/test/html_test.rb
+++ b/test/html_test.rb
@@ -138,3 +138,35 @@ class HtmlTest < Minitest::Test
     refute_includes text, "UNDEFINED"
   end
 end
+
+# Lexxy's attachment tag is configurable (attachmentTagName); the node
+# stores the tag it was created with, and the renderer emits the stored
+# value. The fixture suites above pin the default-tag output.
+class LexxyAttachmentTagTest < Minitest::Test
+  FakeNode = Struct.new(:attrs)
+
+  def test_uses_the_stored_tag_name
+    node = FakeNode.new({ "tagName" => "custom-attachment" })
+
+    assert_equal "custom-attachment", Y::Lexxy.attachment_tag(node)
+  end
+
+  def test_falls_back_when_unset
+    assert_equal "action-text-attachment", Y::Lexxy.attachment_tag(FakeNode.new({}))
+  end
+
+  def test_rejects_a_stored_value_that_is_not_a_tag_name
+    node = FakeNode.new({ "tagName" => 'x onmouseover="' })
+
+    assert_equal "action-text-attachment", Y::Lexxy.attachment_tag(node)
+  end
+
+  def test_upload_and_mention_emit_the_stored_tag
+    node = FakeNode.new({ "tagName" => "my-attachment", "sgid" => "SG1" })
+
+    upload = Y::Lexxy.upload(node)
+    assert_includes upload, '<my-attachment sgid="SG1"'
+    assert upload.end_with?("</my-attachment>")
+    assert Y::Lexxy.mention(node).end_with?("</my-attachment>")
+  end
+end

--- a/test/html_test.rb
+++ b/test/html_test.rb
@@ -165,6 +165,7 @@ class LexxyAttachmentTagTest < Minitest::Test
     node = FakeNode.new({ "tagName" => "my-attachment", "sgid" => "SG1" })
 
     upload = Y::Lexxy.upload(node)
+
     assert_includes upload, '<my-attachment sgid="SG1"'
     assert upload.end_with?("</my-attachment>")
     assert Y::Lexxy.mention(node).end_with?("</my-attachment>")

--- a/test/html_test.rb
+++ b/test/html_test.rb
@@ -143,7 +143,7 @@ end
 # stores the tag it was created with, and the renderer emits the stored
 # value. The fixture suites above pin the default-tag output.
 class LexxyAttachmentTagTest < Minitest::Test
-  FakeNode = Struct.new(:attrs)
+  FakeNode = Data.define(:attrs)
 
   def test_uses_the_stored_tag_name
     node = FakeNode.new({ "tagName" => "custom-attachment" })


### PR DESCRIPTION
Lexxy's configuration system ([lexxy.dev/docs/configuration](https://lexxy.dev/docs/configuration.html)) includes `attachmentTagName`, which changes the tag `lexxy-editor` serializes for ActionText attachments (paired with `ActionText::Attachment.tag_name` on the Rails side). `Y::Lexxy` hardcoded `<action-text-attachment>` in both attachment rules, so a custom-tag app's server-side render would diverge from its editor's output.

Every attachment node stores the tag it was created with — `node_types` on the captured fixtures shows `tagName` in the synced attributes for both `action_text_attachment` and `custom_action_text_attachment` — so the renderer now emits the stored tag. The value is document data, not markup: anything that doesn't match a tag-name shape falls back to the default, which also covers documents from before the tag was stored.

Checked the rest of the configuration surface for output impact: `headings` needs nothing (the renderer already reads the stored heading tag and covers h1–h6, so newly configurable levels come free), `attachmentContentTypeNamespace` flows through stored `contentType` values we already reproduce, and the remaining options (toolbar, markdown, richText, multiLine, permittedAttachmentTypes) restrict input rather than changing serialization.

Full suite: 135 runs green, including the byte-parity fixtures pinning default-tag output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)