### PR TITLE
Extract Y::Sync::Engine; make Y::ActionCable::Sync an adapter over it

### DIFF
--- a/CHANGELOG-rails.md
+++ b/CHANGELOG-rails.md
@@ -10,8 +10,8 @@ this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `Y::ActionCable::Sync` is now a thin adapter over the new transport-neutral
-  `Y::Sync::Engine` (core yrby). Behavior is unchanged — the full protocol test
-  suite passes as-is — but the state machine, reliability, and gap handling now
+  `Y::Sync::Engine` (core yrby). Behavior is unchanged (the full protocol test
+  suite passes as-is), but the state machine, reliability, and gap handling now
   live in the engine, and the concern is just the cable wiring: envelope
   decode, size cap, and routing the engine's result through `transmit` /
   `broadcast`. `MSG_KIND_*` constants moved to `Y::Sync::Engine`. Requires

--- a/CHANGELOG-rails.md
+++ b/CHANGELOG-rails.md
@@ -27,6 +27,12 @@ this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The gem is now `yrby-rails`** (formerly `yrby-actioncable`) and a Rails
   engine. `yrby-actioncable` stops at 0.3.1; `yrby-rails` starts at 0.4.0.
   `Y::ActionCable` keeps its name as the public channel concern.
+- `Y::ActionCable::Sync` is now a thin adapter over the new transport-neutral
+  `Y::Sync::Engine` (core yrby). Behavior is unchanged — the full protocol test
+  suite passes as-is — but the state machine, reliability, and gap handling now
+  live in the engine, and the concern is just the cable wiring: envelope
+  decode, size cap, and routing the engine's result through `transmit` /
+  `broadcast`. `MSG_KIND_*` constants moved to `Y::Sync::Engine`.
 
 ### Added
 

--- a/CHANGELOG-rails.md
+++ b/CHANGELOG-rails.md
@@ -5,6 +5,18 @@ documented here. The
 format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `Y::ActionCable::Sync` is now a thin adapter over the new transport-neutral
+  `Y::Sync::Engine` (core yrby). Behavior is unchanged — the full protocol test
+  suite passes as-is — but the state machine, reliability, and gap handling now
+  live in the engine, and the concern is just the cable wiring: envelope
+  decode, size cap, and routing the engine's result through `transmit` /
+  `broadcast`. `MSG_KIND_*` constants moved to `Y::Sync::Engine`. Requires
+  `yrby >= 0.7.0`, which ships the engine.
+
 ## [0.5.0] - 2026-08-05
 
 ### Added
@@ -27,12 +39,6 @@ this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The gem is now `yrby-rails`** (formerly `yrby-actioncable`) and a Rails
   engine. `yrby-actioncable` stops at 0.3.1; `yrby-rails` starts at 0.4.0.
   `Y::ActionCable` keeps its name as the public channel concern.
-- `Y::ActionCable::Sync` is now a thin adapter over the new transport-neutral
-  `Y::Sync::Engine` (core yrby). Behavior is unchanged — the full protocol test
-  suite passes as-is — but the state machine, reliability, and gap handling now
-  live in the engine, and the concern is just the cable wiring: envelope
-  decode, size cap, and routing the engine's result through `transmit` /
-  `broadcast`. `MSG_KIND_*` constants moved to `Y::Sync::Engine`.
 
 ### Added
 

--- a/CHANGELOG-rails.md
+++ b/CHANGELOG-rails.md
@@ -16,13 +16,14 @@ this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `Y::ActionCable::Sync` is now a thin adapter over the new transport-neutral
-  `Y::Sync::Engine` (core yrby). Behavior is unchanged (the full protocol test
-  suite passes as-is), but the state machine, reliability, and gap handling now
-  live in the engine, and the concern is just the cable wiring: envelope
-  decode, size cap, and routing the engine's result through `transmit` /
-  `broadcast`. `MSG_KIND_*` are canonically on `Y::Sync::Engine` now, aliased under the concern so existing references keep resolving. Requires
-  `yrby >= 0.7.0`, which ships the engine.
+- `Y::ActionCable::Sync` now hands each decoded frame to `Y::Sync::Engine`
+  (core yrby) and routes the reply, broadcast, and ack outcome it returns.
+  Behavior is unchanged. The state machine, causal-gap detection, and
+  record-before-relay decisions live in the engine; the concern keeps
+  envelope decoding, the frame size cap, hook and key validation, cable
+  routing, logging, and ack transmission. `MSG_KIND_*` are canonically on
+  the engine and aliased under the concern, so existing references keep
+  resolving. Requires `yrby >= 0.7.0`, which ships the engine.
 
 ## [0.5.0] - 2026-08-05
 

--- a/CHANGELOG-rails.md
+++ b/CHANGELOG-rails.md
@@ -21,7 +21,7 @@ this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0
   suite passes as-is), but the state machine, reliability, and gap handling now
   live in the engine, and the concern is just the cable wiring: envelope
   decode, size cap, and routing the engine's result through `transmit` /
-  `broadcast`. `MSG_KIND_*` constants moved to `Y::Sync::Engine`. Requires
+  `broadcast`. `MSG_KIND_*` are canonically on `Y::Sync::Engine` now, aliased under the concern so existing references keep resolving. Requires
   `yrby >= 0.7.0`, which ships the engine.
 
 ## [0.5.0] - 2026-08-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `Y::Sync::Engine`: the y-websocket protocol state machine, extracted from
   `Y::ActionCable::Sync` as a transport-neutral core. It takes `load` and
   `change` hooks and turns a decoded frame into a `Result` (reply to the
-  sender, broadcast to peers, ack outcome) — no transport attached. Reliability
+  sender, broadcast to peers, ack outcome), with no transport attached. Reliability
   (ack-tracked delivery, causal-gap detection, integrated-only serving) lives
   here. Any transport that can reply to one client and relay to the rest can
   carry the same protocol: a raw WebSocket, or REST plus a pub/sub bus.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,10 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `Y::Sync::Engine`: the y-websocket protocol state machine, extracted from
   `Y::ActionCable::Sync` as a transport-neutral core. It takes `load` and
-  `change` hooks and turns a decoded frame into a `Result` (reply to the
-  sender, broadcast to peers, ack outcome), with no transport attached. Reliability
-  (ack-tracked delivery, causal-gap detection, integrated-only serving) lives
-  here. Any transport that can reply to one client and relay to the rest can
-  carry the same protocol: a raw WebSocket, or REST plus a pub/sub bus.
+  `change` hooks and turns a decoded frame into a `Result`: bytes to reply
+  with, a frame to relay, and an ack outcome for the transport to act on.
+  Record-before-relay, causal-gap detection, and integrated-only serving are
+  decided here; a transport supplies the routing.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.6.1] - 2026-08-04
 
+### Added
+
+- `Y::Sync::Engine`: the y-websocket protocol state machine, extracted from
+  `Y::ActionCable::Sync` as a transport-neutral core. It takes `load` and
+  `change` hooks and turns a decoded frame into a `Result` (reply to the
+  sender, broadcast to peers, ack outcome) — no transport attached. Reliability
+  (ack-tracked delivery, causal-gap detection, integrated-only serving) lives
+  here. Any transport that can reply to one client and relay to the rest can
+  carry the same protocol: a raw WebSocket, or REST plus a pub/sub bus.
+
 ### Fixed
 
 - `Y::Lexxy` emits the attachment tag the node was created with instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project aims
 to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.1] - 2026-08-04
+## [Unreleased]
 
 ### Added
 
@@ -15,6 +15,8 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (ack-tracked delivery, causal-gap detection, integrated-only serving) lives
   here. Any transport that can reply to one client and relay to the rest can
   carry the same protocol: a raw WebSocket, or REST plus a pub/sub bus.
+
+## [0.6.1] - 2026-08-04
 
 ### Fixed
 

--- a/lib/y.rb
+++ b/lib/y.rb
@@ -15,6 +15,7 @@ end
 require_relative "y/rendering"
 require_relative "y/lexxy"
 require_relative "y/tiptap"
+require_relative "y/sync/engine"
 
 module Y
   # Doc, Error, and the protocol module functions are defined in the Rust

--- a/lib/y.rb
+++ b/lib/y.rb
@@ -19,6 +19,6 @@ require_relative "y/sync/engine"
 
 module Y
   # Doc, Error, and the protocol module functions are defined in the Rust
-  # extension. The ActionCable integration (Y::ActionCable::Sync) lives in the
-  # separate `yrby-actioncable` gem; require "y/action_cable".
+  # extension. The Action Cable integration lives in the yrby-rails gem;
+  # require "y/action_cable".
 end

--- a/lib/y/action_cable/sync.rb
+++ b/lib/y/action_cable/sync.rb
@@ -35,8 +35,9 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
   # There is no unsubscribe hook: the server keeps no per-connection document or
   # presence state, so a disconnect needs no server-side cleanup.
   #
-  # The concern is store-backed: every document update is validated against
-  # `on_load`, recorded through `on_change`, and only then broadcast.
+  # The concern is store-backed: Y::Sync::Engine rebuilds each document
+  # through `on_load`, records a new update through `on_change` before it is
+  # broadcast, and relays an already-stored retry without recording it again.
   # No authoritative document state is kept in ActionCable process memory.
   #
   # The protocol state machine lives in Y::Sync::Engine; this concern is the
@@ -49,8 +50,8 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
     # allocation/parse cost. Override per channel with `max_frame_bytes`.
     DEFAULT_MAX_FRAME_BYTES = 8 * 1024 * 1024
 
-    # The message kinds live on the engine now, with the state machine that
-    # reads them. Kept here because they were reachable under this namespace.
+    # Canonically on the engine, with the state machine that reads them.
+    # Kept in this namespace because they were reachable here.
     MSG_KIND_SYNC_STEP1 = Y::Sync::Engine::MSG_KIND_SYNC_STEP1
     MSG_KIND_UPDATE = Y::Sync::Engine::MSG_KIND_UPDATE
     MSG_KIND_AWARENESS = Y::Sync::Engine::MSG_KIND_AWARENESS
@@ -60,9 +61,10 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
     end
 
     module ClassMethods
-      # Load persisted document state. Called once per key with (key); return a
-      # binary Y.js update (or nil for a fresh document). Runs in the channel
-      # instance's context (instance_exec).
+      # Load persisted document state. Called with (key) every time the engine
+      # rebuilds the document, which is once per handshake and once per
+      # incoming update; return a binary Y.js update, or nil for a fresh
+      # document. Runs in the channel instance's context (instance_exec).
       def on_load(&block)
         @on_load = block if block
         return @on_load if defined?(@on_load) && @on_load
@@ -70,10 +72,12 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
         superclass.respond_to?(:on_load) ? superclass.on_load : nil
       end
 
-      # Record every document change durably before it is applied or
-      # distributed. Called synchronously with (key, update), where update is
-      # the exact CRDT delta. If the block raises, the change is rejected:
-      # neither acknowledged nor broadcast to other subscribers.
+      # Record a new document change durably, before it is broadcast or
+      # acked. Called synchronously with (key, update), where update is the
+      # exact CRDT delta. An update already present in the store is relayed
+      # without calling this again. If the block raises, the change is
+      # rejected: neither acknowledged nor broadcast. Concurrent deliveries
+      # of the same delta can both reach it, so it must tolerate duplicates.
       #
       # Runs in the channel instance's context (instance_exec). Fires from within
       # sync_receive.
@@ -111,9 +115,9 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
       sync_transmit(sync_engine.sync_step1(@sync_key))
     end
 
-    # Call from `receive`. Applies the client's message, replies directly
-    # when the protocol calls for it, and relays document/awareness changes
-    # to the other subscribers.
+    # Call from `receive`. Hands the client's frame to the engine, replies
+    # directly when the protocol calls for it, and relays document and
+    # awareness frames to the document stream.
     #
     # Reliable delivery: document updates carry an "id", and the server replies
     # `{ "ack" => id }` once the update has been durably recorded. A
@@ -146,8 +150,8 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
       begin
         bytes = Base64.strict_decode64(encoded)
       rescue ArgumentError
-        sync_log_drop(:debug, "not valid base64", id) # garbage or a probe, rarely a real client
-        return # ignore the frame and keep the connection
+        sync_log_drop(:debug, "not valid base64", id)
+        return
       end
 
       if cap && bytes.bytesize > cap
@@ -160,11 +164,9 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
 
     private
 
-    # The transport-neutral protocol core. Built with hooks that run on_load /
-    # on_change in THIS channel instance's context (instance_exec), so on_change
-    # can reach current_user, params, and the channel's own methods, the same
-    # binding the old inline recorder had. Memoized per instance; the engine is
-    # stateless, so a fresh one per AnyCable-rebuilt channel costs nothing.
+    # One engine per channel instance. Its hooks run on_load and on_change in
+    # this instance's context (instance_exec), so they can reach current_user,
+    # params, and the channel's own methods.
     def sync_engine
       @sync_engine ||= Y::Sync::Engine.new(
         load: ->(key) { instance_exec(key, &self.class.on_load) },
@@ -203,9 +205,9 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
       { "update" => encoded }
     end
 
-    # Override in the channel to add identifying context to dropped-frame logs --
-    # a user id, a connection id, a request id. Return a short string (or nil for
-    # none); it is appended to the log line. Default: no extra context.
+    # Override in the channel to add identifying context to dropped-frame and
+    # gap-resync logs: a user id, a connection id, a request id. Return a short
+    # string, or nil for none. Default: no extra context.
     def sync_log_context
       nil
     end
@@ -220,7 +222,7 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
       logger.public_send(level) do
         parts = ["key=#{@sync_key.inspect}"]
         parts << "id=#{id}" unless id.nil?
-        # A broken context hook must surface, not take down frame handling.
+        # Report a broken context hook in the log line rather than raising.
         context = begin
           sync_log_context
         rescue StandardError => e
@@ -231,19 +233,15 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
       end
     end
 
-    # Log each causal-gap resync at info. The reject path is otherwise silent
-    # (it transmits a SyncStep1 and returns), so without this there's no way to
-    # see how often clients are sending updates ahead of their dependencies and
-    # forcing a resync. Names the document key and whatever sync_log_context
-    # returns, so frequency can be counted and traced per document.
-    #
-    # One line per forced resync: a client that keeps re-sending the same gapped
-    # update logs on every retry. That's the signal you want, but it can be
-    # chatty; override this method to change the level or silence it.
+    # Log every causal-gap resync with the document key and sync_log_context.
+    # The reject path sends no error to the client, so this is the only
+    # record of how often updates arrive ahead of their dependencies. A
+    # client retrying the same gapped update logs each time; override to
+    # change the level or silence it.
     def sync_log_gap_resync
       logger.info do
         parts = ["key=#{@sync_key.inspect}"]
-        # A broken context hook must surface, not take down frame handling.
+        # Report a broken context hook in the log line rather than raising.
         context = begin
           sync_log_context
         rescue StandardError => e
@@ -254,11 +252,11 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
       end
     end
 
-    # This concern acks updates as durably recorded, so it must have both a
-    # loader (to rebuild the doc and detect causal gaps) and a recorder (to
-    # actually persist before acking). Fail closed rather than silently acking
-    # and broadcasting updates that were never stored, which a cold load or
-    # reconnect would then lose.
+    # Both hooks are required: the engine needs stored state to rebuild the
+    # document and detect causal gaps, and a new update must be persisted
+    # before it is broadcast or acked. Without them the channel would ack and
+    # broadcast updates that were never stored, and a cold load or reconnect
+    # would lose them.
     def sync_validate_required_hooks!
       missing = []
       missing << :on_load unless self.class.on_load
@@ -273,9 +271,9 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
 
     # Fail closed when no document key is set (typically: AnyCable rebuilt the
     # channel instance and the app forgot to pass `key` to sync_receive).
-    # Proceeding would record under nil, broadcast to a stream nobody
-    # subscribes to, and still ack — the client believes the edit was
-    # delivered when it reached no one.
+    # Proceeding would record under nil, broadcast on a stream derived from
+    # nil, and still ack, telling the client an edit landed on a document it
+    # never reached.
     def sync_validate_key!
       return unless @sync_key.nil? || @sync_key.empty?
 
@@ -285,10 +283,11 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
             "doesn't keep the channel instance alive across actions (e.g. AnyCable)."
     end
 
-    # Hand one decoded frame to the engine and route its Result onto the cable:
-    # a direct reply to the sender (a SyncStep2 or a resync request), a
-    # broadcast to the other subscribers, or both/neither. Returns the engine's
-    # ack outcome for sync_send_ack.
+    # Hand one decoded frame to the engine and route its Result onto the
+    # cable: a direct reply to the sender (a SyncStep2 or a resync request),
+    # or a broadcast on the document stream, or neither. Routing happens
+    # before the ack outcome goes back to sync_send_ack, so an ack never
+    # promises delivery that has not been attempted.
     def sync_handle_frame(encoded, bytes)
       sync_validate_required_hooks!
       sync_validate_key!

--- a/lib/y/action_cable/sync.rb
+++ b/lib/y/action_cable/sync.rb
@@ -40,7 +40,7 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
   # No authoritative document state is kept in ActionCable process memory.
   #
   # The protocol state machine lives in Y::Sync::Engine; this concern is the
-  # ActionCable adapter over it — it decodes the cable envelope, calls the
+  # ActionCable adapter over it: it decodes the cable envelope, calls the
   # engine, and routes the result back through `transmit` and
   # `ActionCable.server.broadcast`.
   module Sync
@@ -156,7 +156,7 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
 
     # The transport-neutral protocol core. Built with hooks that run on_load /
     # on_change in THIS channel instance's context (instance_exec), so on_change
-    # can reach current_user, params, and the channel's own methods — the same
+    # can reach current_user, params, and the channel's own methods, the same
     # binding the old inline recorder had. Memoized per instance; the engine is
     # stateless, so a fresh one per AnyCable-rebuilt channel costs nothing.
     def sync_engine

--- a/lib/y/action_cable/sync.rb
+++ b/lib/y/action_cable/sync.rb
@@ -38,14 +38,12 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
   # The concern is store-backed: every document update is validated against
   # `on_load`, recorded through `on_change`, and only then broadcast.
   # No authoritative document state is kept in ActionCable process memory.
+  #
+  # The protocol state machine lives in Y::Sync::Engine; this concern is the
+  # ActionCable adapter over it — it decodes the cable envelope, calls the
+  # engine, and routes the result back through `transmit` and
+  # `ActionCable.server.broadcast`.
   module Sync
-    # Frame kinds we act on, from Y.message_kind. Its other codes (0 for a
-    # drop: malformed/truncated/multi-message/unknown, and 4 for an awareness
-    # query) fall through to a no-op in the dispatch below.
-    MSG_KIND_SYNC_STEP1 = 1
-    MSG_KIND_UPDATE = 2
-    MSG_KIND_AWARENESS = 3
-
     # Default incoming-frame size cap (decoded bytes). Generous enough for a
     # large initial SyncStep2, small enough to bound a single message's
     # allocation/parse cost. Override per channel with `max_frame_bytes`.
@@ -104,7 +102,7 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
       # client path to ephemeral presence rather than the durable document stream.
       stream_from sync_stream_name
       stream_from sync_awareness_stream_name, whisper: true if respond_to?(:whispers_to)
-      sync_transmit(sync_load_doc.sync_step1)
+      sync_transmit(sync_engine.sync_step1(@sync_key))
     end
 
     # Call from `receive`. Applies the client's message, replies directly
@@ -156,12 +154,16 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
 
     private
 
-    # Ask this connection's client to resync: re-send SyncStep1 carrying the
-    # server's current (gap-free) state vector. The client replies SyncStep2
-    # with everything the server is missing, delivered as one causally-complete
-    # delta, which heals the gap that triggered the resync.
-    def sync_request_resync(doc)
-      sync_transmit(doc.sync_step1)
+    # The transport-neutral protocol core. Built with hooks that run on_load /
+    # on_change in THIS channel instance's context (instance_exec), so on_change
+    # can reach current_user, params, and the channel's own methods — the same
+    # binding the old inline recorder had. Memoized per instance; the engine is
+    # stateless, so a fresh one per AnyCable-rebuilt channel costs nothing.
+    def sync_engine
+      @sync_engine ||= Y::Sync::Engine.new(
+        load: ->(key) { instance_exec(key, &self.class.on_load) },
+        change: ->(key, update) { instance_exec(key, update, &self.class.on_change) }
+      )
     end
 
     # Reliable delivery: acknowledge an accepted update back to the sending
@@ -254,65 +256,18 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
             "doesn't keep the channel instance alive across actions (e.g. AnyCable)."
     end
 
-    # Stateless per message: any process can handle any document. A client's
-    # SyncStep1 is answered from the store, document changes are recorded durably
-    # before relay and then broadcast, and awareness is relayed best-effort.
-    # Echoing back to the sender is harmless, since the CRDT apply is idempotent.
-    #
-    # Returns an outcome symbol for the reliable-delivery ack: :recorded when a
-    # document update was durably recorded and relayed, :gap when it was
-    # rejected for a resync, :noop for everything else.
+    # Hand one decoded frame to the engine and route its Result onto the cable:
+    # a direct reply to the sender (a SyncStep2 or a resync request), a
+    # broadcast to the other subscribers, or both/neither. Returns the engine's
+    # ack outcome for sync_send_ack.
     def sync_handle_frame(encoded, bytes)
       sync_validate_required_hooks!
       sync_validate_key!
 
-      case Y.message_kind(bytes)
-      when MSG_KIND_SYNC_STEP1
-        result = sync_load_doc.handle_sync_message(bytes)
-        sync_transmit(result[2])
-        :noop
-      when MSG_KIND_UPDATE
-        update = Y.update_from_message(bytes)
-        return :noop unless update
-
-        # Rebuild from the store (O(history) per update; snapshot in on_load if
-        # that cost bites).
-        doc = sync_load_doc
-
-        # Don't record a causally-incomplete update; resync instead so the gap
-        # heals as one complete delta.
-        unless doc.update_ready?(update)
-          sync_request_resync(doc)
-          return :gap
-        end
-
-        # A lost-ack retry: already recorded, so skip on_change — but DO
-        # re-broadcast. If the first attempt died between record and broadcast,
-        # this retry is the only path left to the live subscribers. Duplicate
-        # broadcasts are free (CRDT apply is idempotent).
-        unless doc.update_advances?(update)
-          sync_distribute(encoded)
-          return :applied
-        end
-
-        sync_record_change(update) # record before relay
-        sync_distribute(encoded)
-        :recorded
-      when MSG_KIND_AWARENESS
-        sync_distribute(encoded)
-        :noop
-      else
-        :noop
-      end
-    end
-
-    # Build a fresh document from the durable store (on_load). Callers validate
-    # the hooks first, so on_load is present; a nil state means a fresh document.
-    def sync_load_doc
-      doc = Y::Doc.new
-      state = instance_exec(@sync_key, &self.class.on_load)
-      doc.apply_update(state) if state
-      doc
+      result = sync_engine.handle(@sync_key, encoded, bytes)
+      sync_transmit(result.reply) if result.reply
+      sync_distribute(result.broadcast) if result.broadcast
+      result.ack
     end
 
     def sync_stream_name
@@ -321,13 +276,6 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
 
     def sync_awareness_stream_name
       "#{sync_stream_name}:awareness"
-    end
-
-    # Invoke the on_change recorder in this channel instance's context
-    # (instance_exec) so it can reach the channel's own methods. Mirrors how
-    # sync_load_doc fetches and runs on_load.
-    def sync_record_change(update)
-      instance_exec(@sync_key, update, &self.class.on_change)
     end
   end
 end

--- a/lib/y/action_cable/sync.rb
+++ b/lib/y/action_cable/sync.rb
@@ -177,12 +177,13 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
     # Reliable delivery: acknowledge an accepted update back to the sending
     # connection. An ack-aware client tags each outgoing update with an "id"
     # and retains it until the matching `{ "ack" => id }` returns, retransmitting
-    # on a timer or reconnect; idempotent CRDT apply makes resends free. Acks
-    # are sent only after the update has been durably recorded, or when a retry
-    # is already present in the durable store.
-    def sync_send_ack(id, outcome)
+    # on a timer or reconnect; applying a CRDT update twice is safe. Which
+    # outcomes are ackable is the engine's call (Result#ack?), so the two can't
+    # drift as outcomes are added; sync_handle_frame has already routed the
+    # reply or broadcast by the time this runs.
+    def sync_send_ack(id, result)
       return if id.nil?
-      return unless %i[recorded applied].include?(outcome)
+      return unless result.ack?
 
       # The braces are required: a bare hash would bind to transmit's `via:`
       # keyword instead of its positional data argument.
@@ -285,9 +286,8 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
 
     # Hand one decoded frame to the engine and route its Result onto the
     # cable: a direct reply to the sender (a SyncStep2 or a resync request),
-    # or a broadcast on the document stream, or neither. Routing happens
-    # before the ack outcome goes back to sync_send_ack, so an ack never
-    # promises delivery that has not been attempted.
+    # or a broadcast on the document stream, or neither. Returns the Result,
+    # routed, so sync_send_ack never acks delivery that wasn't attempted.
     def sync_handle_frame(encoded, bytes)
       sync_validate_required_hooks!
       sync_validate_key!
@@ -296,7 +296,7 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
       sync_transmit(result.reply) if result.reply
       sync_distribute(result.broadcast) if result.broadcast
       sync_log_gap_resync if result.ack == :gap
-      result.ack
+      result
     end
 
     def sync_stream_name

--- a/lib/y/action_cable/sync.rb
+++ b/lib/y/action_cable/sync.rb
@@ -49,6 +49,12 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
     # allocation/parse cost. Override per channel with `max_frame_bytes`.
     DEFAULT_MAX_FRAME_BYTES = 8 * 1024 * 1024
 
+    # The message kinds live on the engine now, with the state machine that
+    # reads them. Kept here because they were reachable under this namespace.
+    MSG_KIND_SYNC_STEP1 = Y::Sync::Engine::MSG_KIND_SYNC_STEP1
+    MSG_KIND_UPDATE = Y::Sync::Engine::MSG_KIND_UPDATE
+    MSG_KIND_AWARENESS = Y::Sync::Engine::MSG_KIND_AWARENESS
+
     def self.included(base)
       base.extend(ClassMethods)
     end

--- a/lib/y/sync/engine.rb
+++ b/lib/y/sync/engine.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+module Y
+  module Sync
+    # The transport-neutral yrby sync core: the y-websocket protocol state
+    # machine, with no transport attached.
+    #
+    # `Y::ActionCable::Sync` is a thin adapter over this — it decodes the cable
+    # envelope, calls {#handle}, and routes the {Result} back through
+    # `transmit` / `ActionCable.server.broadcast`. Those routing calls are the
+    # only thing that ties collaboration to ActionCable. Any transport that can
+    # deliver a reply to one client and relay a frame to the rest can carry the
+    # same protocol: a raw WebSocket, or REST plus a pub/sub bus (Discourse's
+    # MessageBus), for instance.
+    #
+    # The engine holds no per-connection or per-document state. Every call
+    # rebuilds the document from the store through the `load` hook, so one
+    # engine is safe to share across connections, requests, and threads — the
+    # same statelessness that lets any process serve any document.
+    #
+    #   engine = Y::Sync::Engine.new(
+    #     load:   ->(key)         { MyStore.load(key) },      # bytes, or nil
+    #     change: ->(key, update) { MyStore.append(key, update) }
+    #   )
+    #
+    # Reliability (ack-tracked delivery, causal-gap detection, integrated-only
+    # serving) lives here, because it is the yrs calls themselves —
+    # `update_ready?`, `update_advances?`, `handle_sync_message`,
+    # `compacted_state_update`.
+    class Engine
+      # Frame kinds from Y.message_kind. Its other codes (0 for a drop, 4 for
+      # an awareness query) fall through to a no-op.
+      MSG_KIND_SYNC_STEP1 = 1
+      MSG_KIND_UPDATE = 2
+      MSG_KIND_AWARENESS = 3
+
+      # What the transport should do with a handled frame. Exactly one of
+      # `reply` / `broadcast` is set in every branch, but they are separate
+      # fields so a transport routes them without re-inspecting the frame.
+      #
+      # - `reply`     raw protocol bytes to send back to THIS client only (a
+      #               SyncStep2 answering a SyncStep1, or a resync request), or
+      #               nil.
+      # - `broadcast` the caller-supplied encoded frame to relay to the OTHER
+      #               clients on this document, or nil.
+      # - `ack`       the reliable-delivery outcome: :recorded (durably stored
+      #               and relayed), :applied (a lost-ack retry, re-relayed but
+      #               not re-recorded), :gap (rejected, resync requested), or
+      #               :noop. See {#ack?}.
+      Result = Data.define(:reply, :broadcast, :ack) do
+        # Reliable-delivery clients are acked only once an update is durably
+        # recorded (:recorded), or on an already-present retry that was still
+        # relayed (:applied). A gap or a no-op is never acked.
+        def ack?
+          %i[recorded applied].include?(ack)
+        end
+      end
+
+      # `load`   — called with (key); returns a binary Y.js update to rebuild
+      #            the document, or nil for a fresh one.
+      # `change` — called with (key, update) to record a delta durably. Runs
+      #            before the update is acked or relayed; if it raises, the
+      #            change is rejected (neither happens) and the raise
+      #            propagates to the caller.
+      def initialize(load:, change:)
+        @load = load
+        @change = change
+      end
+
+      # The opening handshake frame for a joining client over a bidirectional
+      # transport: the server's SyncStep1 (its state vector). The client
+      # answers with a SyncStep2 carrying anything the server is missing. This
+      # is what `Y::ActionCable::Sync` transmits from `subscribed`.
+      def sync_step1(key)
+        load_doc(key).sync_step1
+      end
+
+      # The current document state as one gap-free update, for a joiner over a
+      # request/response transport (REST) that applies it directly rather than
+      # diffing. `compacted_state_update` (not `encode_state_as_update`) so a
+      # joiner never receives pending structs it cannot integrate.
+      def full_state(key)
+        load_doc(key).compacted_state_update
+      end
+
+      # Handle one decoded frame for `key` and return a {Result}. `encoded` is
+      # the frame in whatever form the transport relays (the cable adapter
+      # passes the base64 string, so an echoed broadcast matches the wire
+      # format); `bytes` is its decoded form, which the protocol reads. The
+      # engine relays `encoded` verbatim and never inspects the transport's
+      # encoding.
+      def handle(key, encoded, bytes)
+        case Y.message_kind(bytes)
+        when MSG_KIND_SYNC_STEP1
+          # Answer the client's state vector with an integrated-only SyncStep2
+          # (handle_sync_message never serves pending structs).
+          reply = load_doc(key).handle_sync_message(bytes)[2]
+          Result.new(reply: reply, broadcast: nil, ack: :noop)
+        when MSG_KIND_UPDATE
+          handle_update(key, encoded, bytes)
+        when MSG_KIND_AWARENESS
+          # Ephemeral presence: relay, never record.
+          Result.new(reply: nil, broadcast: encoded, ack: :noop)
+        else
+          noop
+        end
+      end
+
+      private
+
+      def handle_update(key, encoded, bytes)
+        update = Y.update_from_message(bytes)
+        return noop unless update
+
+        # Rebuild from the store (O(history) per update; snapshot in `load` if
+        # that cost bites).
+        doc = load_doc(key)
+
+        # Don't record a causally-incomplete update; request a resync so the
+        # gap heals as one complete delta.
+        return Result.new(reply: doc.sync_step1, broadcast: nil, ack: :gap) unless doc.update_ready?(update)
+
+        # A lost-ack retry: already recorded, so skip `change` — but DO
+        # re-relay. If the first attempt died between record and broadcast,
+        # this retry is the only path left to the live subscribers. Duplicate
+        # relays are free (CRDT apply is idempotent).
+        return Result.new(reply: nil, broadcast: encoded, ack: :applied) unless doc.update_advances?(update)
+
+        @change.call(key, update) # record before relay
+        Result.new(reply: nil, broadcast: encoded, ack: :recorded)
+      end
+
+      def load_doc(key)
+        doc = Y::Doc.new
+        state = @load.call(key)
+        doc.apply_update(state) if state
+        doc
+      end
+
+      def noop
+        Result.new(reply: nil, broadcast: nil, ack: :noop)
+      end
+    end
+  end
+end

--- a/lib/y/sync/engine.rb
+++ b/lib/y/sync/engine.rb
@@ -5,31 +5,28 @@ module Y
     # The transport-neutral yrby sync core: the y-websocket protocol state
     # machine, with no transport attached.
     #
-    # `Y::ActionCable::Sync` is a thin adapter over this: it decodes the cable
-    # envelope, calls {#handle}, and routes the {Result} back through
-    # `transmit` / `ActionCable.server.broadcast`. Those routing calls are the
-    # only thing that ties collaboration to ActionCable. Any transport that can
-    # deliver a reply to one client and relay a frame to the rest can carry the
-    # same protocol: a raw WebSocket, or REST plus a pub/sub bus (Discourse's
-    # MessageBus), for instance.
+    # `Y::ActionCable::Sync` decodes the cable envelope, calls {#handle}, and
+    # routes the {Result} through `transmit` and `ActionCable.server.broadcast`.
+    # Another transport supplies its own routing for the same Results.
     #
-    # The engine adds no mutable protocol state. Every call rebuilds the
-    # document from the store through the `load` hook, which is what lets any
-    # process serve any document. Sharing one engine across connections,
-    # requests, or threads is therefore only as safe as its hooks: they must
-    # be thread-safe and must not close over one connection's state. The
-    # ActionCable adapter builds an engine per channel instance, whose hooks
-    # deliberately capture that channel.
+    # The engine adds no mutable protocol state. Document frames rebuild from
+    # the store through the `load` hook, which is what lets any process serve
+    # any document. Sharing one engine is therefore only as safe as its
+    # hooks: they must be thread-safe, and must not close over a single
+    # connection's state. Two concurrent calls can also classify the same
+    # delta as new and both call `change`, so a recorder must tolerate
+    # duplicates. The ActionCable adapter builds one engine per channel
+    # instance, whose hooks capture that channel on purpose.
     #
     #   engine = Y::Sync::Engine.new(
     #     load:   ->(key)         { MyStore.load(key) },      # bytes, or nil
     #     change: ->(key, update) { MyStore.append(key, update) }
     #   )
     #
-    # Reliability (ack-tracked delivery, causal-gap detection, integrated-only
-    # serving) lives here, because it is the yrs calls themselves;
-    # `update_ready?`, `update_advances?`, `handle_sync_message`,
-    # `compacted_state_update`.
+    # The engine decides the ack outcome and owns causal-gap detection and
+    # integrated-only serving, through `update_ready?`, `update_advances?`,
+    # `handle_sync_message`, and `compacted_state_update`. Transmitting the
+    # ack is the transport's job.
     class Engine
       # Frame kinds from Y.message_kind. Its other codes (0 for a drop, 4 for
       # an awareness query) fall through to a no-op.
@@ -55,13 +52,14 @@ module Y
       #               :gap (rejected, resync requested), or :noop. See
       #               {#ack?}.
       #
-      # The branches: a SyncStep1 replies only; an update either broadcasts
-      # (:recorded, :applied) or replies (:gap); awareness broadcasts only;
-      # anything else sets neither (:noop).
+      # The branches: a SyncStep1 replies only; a valid update either
+      # broadcasts (:recorded, :applied) or replies (:gap); awareness
+      # broadcasts only; an unreadable update and any other kind set neither
+      # (:noop).
       Result = Data.define(:reply, :broadcast, :ack) do
-        # Reliable-delivery clients are acked only once an update is durably
-        # recorded (:recorded), or on an already-present retry that was still
-        # relayed (:applied). A gap or a no-op is never acked.
+        # The outcomes a transport should ack: :recorded, whose delta the
+        # `change` hook stored, and :applied, an already-present retry the
+        # transport relays again. A gap or a no-op is never acked.
         def ack?
           %i[recorded applied].include?(ack)
         end
@@ -86,10 +84,9 @@ module Y
         load_doc(key).sync_step1
       end
 
-      # The current document state as one gap-free update, for a joiner over a
-      # request/response transport (REST) that applies it directly rather than
-      # diffing. `compacted_state_update` (not `encode_state_as_update`) so a
-      # joiner never receives pending structs it cannot integrate.
+      # The current integrated state as one gap-free update, for a joiner
+      # that applies it directly instead of diffing. `compacted_state_update`
+      # excludes pending structs, which a joiner cannot integrate.
       def full_state(key)
         load_doc(key).compacted_state_update
       end
@@ -123,8 +120,6 @@ module Y
         update = Y.update_from_message(bytes)
         return noop unless update
 
-        # Rebuild from the store (O(history) per update; snapshot in `load` if
-        # that cost bites).
         doc = load_doc(key)
 
         # Don't record a causally-incomplete update; request a resync so the
@@ -133,8 +128,8 @@ module Y
 
         # A lost-ack retry: already recorded, so skip `change`, but do
         # re-relay. If the first attempt died between record and broadcast,
-        # this retry is the only path left to the live subscribers. Duplicate
-        # relays are free (CRDT apply is idempotent).
+        # this retry is the only path left to the live subscribers. Relaying
+        # it twice is safe, since applying a CRDT update is idempotent.
         return Result.new(reply: nil, broadcast: encoded, ack: :applied) unless doc.update_advances?(update)
 
         @change.call(key, update) # record before relay

--- a/lib/y/sync/engine.rb
+++ b/lib/y/sync/engine.rb
@@ -13,10 +13,13 @@ module Y
     # same protocol: a raw WebSocket, or REST plus a pub/sub bus (Discourse's
     # MessageBus), for instance.
     #
-    # The engine holds no per-connection or per-document state. Every call
-    # rebuilds the document from the store through the `load` hook, so one
-    # engine is safe to share across connections, requests, and threads; the
-    # same statelessness that lets any process serve any document.
+    # The engine adds no mutable protocol state. Every call rebuilds the
+    # document from the store through the `load` hook, which is what lets any
+    # process serve any document. Sharing one engine across connections,
+    # requests, or threads is therefore only as safe as its hooks: they must
+    # be thread-safe and must not close over one connection's state. The
+    # ActionCable adapter builds an engine per channel instance, whose hooks
+    # deliberately capture that channel.
     #
     #   engine = Y::Sync::Engine.new(
     #     load:   ->(key)         { MyStore.load(key) },      # bytes, or nil
@@ -34,19 +37,27 @@ module Y
       MSG_KIND_UPDATE = 2
       MSG_KIND_AWARENESS = 3
 
-      # What the transport should do with a handled frame. Exactly one of
-      # `reply` / `broadcast` is set in every branch, but they are separate
-      # fields so a transport routes them without re-inspecting the frame.
+      # What the transport should do with a handled frame. Each field is
+      # separate so a transport routes it without re-inspecting the frame.
+      # Route before acking: an ack promises the work already happened.
       #
-      # - `reply`     raw protocol bytes to send back to THIS client only (a
-      #               SyncStep2 answering a SyncStep1, or a resync request), or
-      #               nil.
-      # - `broadcast` the caller-supplied encoded frame to relay to the OTHER
-      #               clients on this document, or nil.
-      # - `ack`       the reliable-delivery outcome: :recorded (durably stored
-      #               and relayed), :applied (a lost-ack retry, re-relayed but
-      #               not re-recorded), :gap (rejected, resync requested), or
-      #               :noop. See {#ack?}.
+      # - `reply`     raw protocol bytes for the client that sent this frame
+      #               (a SyncStep2 answering a SyncStep1, or a resync
+      #               request), or nil.
+      # - `broadcast` the caller-supplied encoded frame to relay to the
+      #               document's subscribers, or nil. Who receives it is the
+      #               transport's policy; the ActionCable adapter broadcasts
+      #               to a stream that includes the sender, which is harmless
+      #               because applying a CRDT update is idempotent.
+      # - `ack`       the reliable-delivery outcome: :recorded (durably
+      #               stored, and the caller should relay it), :applied (a
+      #               lost-ack retry, relay again but do not re-record),
+      #               :gap (rejected, resync requested), or :noop. See
+      #               {#ack?}.
+      #
+      # The branches: a SyncStep1 replies only; an update either broadcasts
+      # (:recorded, :applied) or replies (:gap); awareness broadcasts only;
+      # anything else sets neither (:noop).
       Result = Data.define(:reply, :broadcast, :ack) do
         # Reliable-delivery clients are acked only once an update is durably
         # recorded (:recorded), or on an already-present retry that was still

--- a/lib/y/sync/engine.rb
+++ b/lib/y/sync/engine.rb
@@ -5,7 +5,7 @@ module Y
     # The transport-neutral yrby sync core: the y-websocket protocol state
     # machine, with no transport attached.
     #
-    # `Y::ActionCable::Sync` is a thin adapter over this — it decodes the cable
+    # `Y::ActionCable::Sync` is a thin adapter over this: it decodes the cable
     # envelope, calls {#handle}, and routes the {Result} back through
     # `transmit` / `ActionCable.server.broadcast`. Those routing calls are the
     # only thing that ties collaboration to ActionCable. Any transport that can
@@ -15,7 +15,7 @@ module Y
     #
     # The engine holds no per-connection or per-document state. Every call
     # rebuilds the document from the store through the `load` hook, so one
-    # engine is safe to share across connections, requests, and threads — the
+    # engine is safe to share across connections, requests, and threads; the
     # same statelessness that lets any process serve any document.
     #
     #   engine = Y::Sync::Engine.new(
@@ -24,7 +24,7 @@ module Y
     #   )
     #
     # Reliability (ack-tracked delivery, causal-gap detection, integrated-only
-    # serving) lives here, because it is the yrs calls themselves —
+    # serving) lives here, because it is the yrs calls themselves;
     # `update_ready?`, `update_advances?`, `handle_sync_message`,
     # `compacted_state_update`.
     class Engine
@@ -56,9 +56,9 @@ module Y
         end
       end
 
-      # `load`   — called with (key); returns a binary Y.js update to rebuild
+      # `load`:   called with (key); returns a binary Y.js update to rebuild
       #            the document, or nil for a fresh one.
-      # `change` — called with (key, update) to record a delta durably. Runs
+      # `change`: called with (key, update) to record a delta durably. Runs
       #            before the update is acked or relayed; if it raises, the
       #            change is rejected (neither happens) and the raise
       #            propagates to the caller.
@@ -120,7 +120,7 @@ module Y
         # gap heals as one complete delta.
         return Result.new(reply: doc.sync_step1, broadcast: nil, ack: :gap) unless doc.update_ready?(update)
 
-        # A lost-ack retry: already recorded, so skip `change` — but DO
+        # A lost-ack retry: already recorded, so skip `change`, but do
         # re-relay. If the first attempt died between record and broadcast,
         # this retry is the only path left to the live subscribers. Duplicate
         # relays are free (CRDT apply is idempotent).

--- a/lib/y/version.rb
+++ b/lib/y/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Y
-  VERSION = "0.7.0"
+  VERSION = "0.6.1"
 end

--- a/lib/y/version.rb
+++ b/lib/y/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Y
-  VERSION = "0.6.1"
+  VERSION = "0.7.0"
 end

--- a/lib/y/version.rb
+++ b/lib/y/version.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
 module Y
-  VERSION = "0.6.1"
+  # Ahead of the last release: yrby-rails in this repo requires the engine
+  # this version adds, and the demo resolves both gems by path, so the floor
+  # has to be satisfiable here before the release goes out.
+  VERSION = "0.7.0"
 end

--- a/test/sync_engine_test.rb
+++ b/test/sync_engine_test.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "fixtures/yjs_fixtures"
+require "base64"
+
+# Y::Sync::Engine on its own, with no transport. Y::ActionCable::Sync is one
+# adapter over it (see sync_test.rb); these pin the protocol core directly, so
+# a second adapter (a REST + pub/sub binding, say) inherits the same
+# guarantees. Every update here is a real Yjs delta captured from Y.js, since
+# a Doc is read-only from Ruby — the client produces updates, the engine
+# relays/records/reads them opaquely.
+class SyncEngineTest < Minitest::Test
+  HELLO = YjsFixtures::TextHelloWorld::UPDATE  # "hello world" on "content"
+  DOC1 = YjsFixtures::TwoDocsMerged::DOC1_UPDATE
+  DOC2 = YjsFixtures::TwoDocsMerged::DOC2_UPDATE
+  CHAIN = YjsFixtures::CausalChain             # U1/U2/U3 -> A/B/C; U2 depends on U1
+  PRESENCE = YjsFixtures::Presence::FRAME
+
+  # An append-log store, like the ActionCable tests use. `load` merges it.
+  def build_engine(store: [], recorder: nil)
+    recorder ||= ->(_key, update) { store << update }
+    loader = ->(_key) { merged(store) }
+    [Y::Sync::Engine.new(load: loader, change: recorder), store]
+  end
+
+  def merged(updates)
+    return nil if updates.empty?
+
+    doc = Y::Doc.new
+    updates.each { |u| doc.apply_update(u) }
+    doc.encode_state_as_update
+  end
+
+  def frame(update) = Y.wrap_update(update)
+
+  def handle(engine, update)
+    f = frame(update)
+    engine.handle("doc", Base64.strict_encode64(f), f)
+  end
+
+  # --- recording + relay ---
+
+  def test_a_new_update_is_recorded_and_relayed
+    engine, store = build_engine
+    result = handle(engine, HELLO)
+
+    assert_equal :recorded, result.ack
+    assert_predicate result, :ack?, "a recorded update is acked"
+    refute_nil result.broadcast, "and relayed to peers"
+    assert_nil result.reply, "with no direct reply"
+    assert_equal [HELLO], store, "the delta was appended to the store"
+  end
+
+  def test_change_records_before_relay
+    order = []
+    recorder = ->(_key, _update) { order << :recorded }
+    engine, = build_engine(recorder: recorder)
+
+    result = handle(engine, HELLO)
+    order << :relayed if result.broadcast
+
+    assert_equal %i[recorded relayed], order, "record precedes relay"
+  end
+
+  def test_a_raising_recorder_rejects_the_update
+    engine, = build_engine(recorder: ->(_k, _u) { raise "store down" })
+
+    assert_raises(RuntimeError) { handle(engine, HELLO) }
+  end
+
+  # --- reliable delivery ---
+
+  def test_a_lost_ack_retry_is_relayed_but_not_re_recorded
+    store = [HELLO]
+    engine, = build_engine(store: store)
+
+    result = handle(engine, HELLO) # same update again
+
+    assert_equal :applied, result.ack
+    assert_predicate result, :ack?, "a retry is still acked"
+    refute_nil result.broadcast, "and re-relayed (the first relay may have been lost)"
+    assert_equal [HELLO], store, "but not recorded twice"
+  end
+
+  # --- causal gaps ---
+
+  def test_a_gappy_update_is_rejected_with_a_resync
+    engine, store = build_engine
+
+    result = handle(engine, CHAIN::U2) # depends on U1, which the store lacks
+
+    assert_equal :gap, result.ack
+    refute_predicate result, :ack?, "a gap is not acked"
+    assert_nil result.broadcast, "and not relayed"
+    refute_nil result.reply, "the reply is a resync request (server SyncStep1)"
+    assert_equal Y::Sync::Engine::MSG_KIND_SYNC_STEP1, Y.message_kind(result.reply)
+    assert_empty store, "nothing recorded"
+  end
+
+  def test_a_complete_delta_after_a_gap_records_and_recovers
+    engine, = build_engine
+
+    handle(engine, CHAIN::U2) # gap
+    complete = merged([CHAIN::U1, CHAIN::U2]) # what the resync would resend
+    result = handle(engine, complete)
+
+    assert_equal :recorded, result.ack
+    assert_equal "AB", Y::Doc.new.tap { |d| d.apply_update(engine.full_state("doc")) }.read_text("content")
+  end
+
+  # --- sync handshake ---
+
+  def test_sync_step1_frame_answers_from_the_store
+    engine, = build_engine(store: [DOC1])
+
+    frame = engine.sync_step1("doc")
+
+    assert_equal Y::Sync::Engine::MSG_KIND_SYNC_STEP1, Y.message_kind(frame)
+  end
+
+  def test_incoming_sync_step1_gets_a_reply_not_a_broadcast
+    engine, = build_engine(store: [DOC1])
+
+    # A client's SyncStep1 (its empty state vector) — answered with a SyncStep2.
+    step1 = Y::Doc.new.sync_step1
+    result = engine.handle("doc", Base64.strict_encode64(step1), step1)
+
+    refute_nil result.reply, "answered with the client's missing updates"
+    assert_nil result.broadcast, "not relayed to peers"
+    assert_equal :noop, result.ack, "a handshake is not an ack-able update"
+  end
+
+  def test_full_state_is_gap_free
+    engine, = build_engine(store: [DOC1, DOC2])
+
+    doc = Y::Doc.new
+    doc.apply_update(engine.full_state("doc"))
+
+    assert_equal "from doc1from doc2", doc.read_text("content")
+  end
+
+  # --- awareness ---
+
+  def test_awareness_relays_without_recording
+    engine, store = build_engine
+
+    result = engine.handle("doc", Base64.strict_encode64(PRESENCE), PRESENCE)
+
+    refute_nil result.broadcast, "presence is relayed"
+    assert_equal :noop, result.ack, "and never acked"
+    assert_empty store, "and never recorded"
+  end
+
+  # --- junk ---
+
+  def test_an_unclassifiable_frame_is_a_noop
+    engine, store = build_engine
+    junk = "not a protocol frame"
+
+    result = engine.handle("doc", Base64.strict_encode64(junk), junk)
+
+    assert_nil result.reply
+    assert_nil result.broadcast
+    assert_equal :noop, result.ack
+    assert_empty store
+  end
+end

--- a/test/sync_engine_test.rb
+++ b/test/sync_engine_test.rb
@@ -5,11 +5,10 @@ require_relative "fixtures/yjs_fixtures"
 require "base64"
 
 # Y::Sync::Engine on its own, with no transport. Y::ActionCable::Sync is one
-# adapter over it (see sync_test.rb); these pin the protocol core directly, so
-# a second adapter (a REST + pub/sub binding, say) inherits the same
-# guarantees. Every update here is a real Yjs delta captured from Y.js, since
-# a Doc is read-only from Ruby; the client produces updates, the engine
-# relays/records/reads them opaquely.
+# adapter over it, covered in sync_test.rb; these pin the protocol core
+# directly, so what a second adapter inherits is tested here rather than
+# through a cable. Every update is a real Yjs delta captured from Y.js,
+# because a Doc is read-only from Ruby.
 class SyncEngineTest < Minitest::Test
   HELLO = YjsFixtures::TextHelloWorld::UPDATE  # "hello world" on "content"
   DOC1 = YjsFixtures::TwoDocsMerged::DOC1_UPDATE

--- a/test/sync_engine_test.rb
+++ b/test/sync_engine_test.rb
@@ -8,7 +8,7 @@ require "base64"
 # adapter over it (see sync_test.rb); these pin the protocol core directly, so
 # a second adapter (a REST + pub/sub binding, say) inherits the same
 # guarantees. Every update here is a real Yjs delta captured from Y.js, since
-# a Doc is read-only from Ruby — the client produces updates, the engine
+# a Doc is read-only from Ruby; the client produces updates, the engine
 # relays/records/reads them opaquely.
 class SyncEngineTest < Minitest::Test
   HELLO = YjsFixtures::TextHelloWorld::UPDATE  # "hello world" on "content"
@@ -122,7 +122,7 @@ class SyncEngineTest < Minitest::Test
   def test_incoming_sync_step1_gets_a_reply_not_a_broadcast
     engine, = build_engine(store: [DOC1])
 
-    # A client's SyncStep1 (its empty state vector) — answered with a SyncStep2.
+    # A client's SyncStep1 (its empty state vector), answered with a SyncStep2.
     step1 = Y::Doc.new.sync_step1
     result = engine.handle("doc", Base64.strict_encode64(step1), step1)
 

--- a/test/sync_test.rb
+++ b/test/sync_test.rb
@@ -103,7 +103,7 @@ class SyncTest < Minitest::Test
 
     response = Base64.strict_decode64(helper.transmits.first["update"])
 
-    assert_equal Y::ActionCable::Sync::MSG_KIND_SYNC_STEP1,
+    assert_equal Y::Sync::Engine::MSG_KIND_SYNC_STEP1,
                  Y.message_kind(response)
   end
 

--- a/test/sync_test.rb
+++ b/test/sync_test.rb
@@ -103,7 +103,7 @@ class SyncTest < Minitest::Test
 
     response = Base64.strict_decode64(helper.transmits.first["update"])
 
-    assert_equal Y::Sync::Engine::MSG_KIND_SYNC_STEP1,
+    assert_equal Y::ActionCable::Sync::MSG_KIND_SYNC_STEP1,
                  Y.message_kind(response)
   end
 

--- a/yrby-rails.gemspec
+++ b/yrby-rails.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "base64", "~> 0.2"
   spec.add_dependency "railties", ">= 7.1"
   # 0.7.0 ships Y::Sync::Engine, which the concern is now an adapter over.
-  # (It also subsumes 0.3.1's exact update_ready?, which the channel gates
+  # (It also subsumes 0.3.1's exact update_ready?, which the engine gates
   # recording on.)
   spec.add_dependency "yrby", ">= 0.7.0"
   # The concern calls ActionCable.server directly, and railties doesn't

--- a/yrby-rails.gemspec
+++ b/yrby-rails.gemspec
@@ -38,9 +38,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">= 7.1"
   spec.add_dependency "base64", "~> 0.2"
   spec.add_dependency "railties", ">= 7.1"
-  # 0.7.0 ships Y::Sync::Engine, which the concern is now an adapter over.
-  # (It also subsumes 0.3.1's exact update_ready?, which the engine gates
-  # recording on.)
+  # Y::ActionCable::Sync delegates protocol handling to Y::Sync::Engine,
+  # added in 0.7.0.
   spec.add_dependency "yrby", ">= 0.7.0"
   # The concern calls ActionCable.server directly, and railties doesn't
   # depend on actioncable, so declare it. activesupport comes along with

--- a/yrby-rails.gemspec
+++ b/yrby-rails.gemspec
@@ -38,9 +38,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">= 7.1"
   spec.add_dependency "base64", "~> 0.2"
   spec.add_dependency "railties", ">= 7.1"
-  # 0.3.1's update_ready? is exact for cross-client gaps; the channel gates
-  # recording on it, and an older core could ack-and-drop real content.
-  spec.add_dependency "yrby", ">= 0.3.1"
+  # 0.7.0 ships Y::Sync::Engine, which the concern is now an adapter over.
+  # (It also subsumes 0.3.1's exact update_ready?, which the channel gates
+  # recording on.)
+  spec.add_dependency "yrby", ">= 0.7.0"
   # The concern calls ActionCable.server directly, and railties doesn't
   # depend on actioncable, so declare it. activesupport comes along with
   # activerecord either way; listed because the gem uses it directly.


### PR DESCRIPTION
Extracts the sync state machine from `Y::ActionCable::Sync` into a transport-neutral `Y::Sync::Engine` and reworks the ActionCable class into an adapter over it.

`Y::ActionCable::Sync` had the y-websocket state machine baked into the channel, routing results through `transmit`, `stream_from`, and `ActionCable.server.broadcast`. Those three calls were the only thing tying the protocol to ActionCable. Pulling the state machine out lets a second transport (a raw WebSocket, or REST plus a pub/sub bus) be another adapter over one core instead of a reimplementation of the reliability logic.

`Y::Sync::Engine` (core `yrby`, `lib/y/sync/engine.rb`) holds the state machine with no transport. It takes `load`/`change` hooks, and `handle(key, encoded, bytes)` returns a `Result(reply, broadcast, ack)`. Ack-tracked delivery, causal-gap detection, and integrated-only serving live here because they are the yrs calls (`update_ready?`, `update_advances?`, `handle_sync_message`, `compacted_state_update`). It also exposes `sync_step1` and `full_state` (gap-free state for a request/response joiner). The engine adds no mutable protocol state, so sharing one across connections is as safe as its hooks are; the adapter builds one per channel instance, with hooks that capture that channel.

`Y::ActionCable::Sync` becomes the cable adapter: envelope decode, size cap, validations, and routing the engine's `Result` through `transmit`/`broadcast`. Its hooks still run `on_load`/`on_change` in the channel instance's context via `instance_exec`, so `on_change` can reach `current_user`, `params`, and channel methods. It drops from 357 to 305 lines.

`MSG_KIND_*` are canonically on the engine now and aliased under the concern, since they were reachable as `Y::ActionCable::Sync::MSG_KIND_*` and an app or adapter referencing them should keep working.

Causal-gap resync logging stays in the adapter, driven by the engine's ack (`sync_log_gap_resync if result.ack == :gap`). The log line names the document key and `sync_log_context`, both cable concerns, so the engine reports the outcome and the transport decides how to record it.

Core `yrby` goes to 0.7.0 and the `yrby-rails` floor rises to `yrby >= 0.7.0`. The bump has to happen here rather than at release prep: the demo resolves both gems by path, so a floor above the tree's own version makes its bundle unsolvable. The changelog entry stays under `[Unreleased]` until release prep stamps it.

Behavior is unchanged, and `sync_test.rb` passes with no edits at all. A new `sync_engine_test.rb` pins the core directly (11 tests): record+relay, record-before-relay ordering, raising-recorder rejection, lost-ack retry, gap→resync→recover, handshake reply-not-broadcast, gap-free `full_state`, awareness relay, and junk frames. Each update is a captured Yjs delta, since a `Doc` is read-only from Ruby.

Full suite: 183 runs, 0 failures; rubocop clean. The engine ships in core `yrby`, not duplicated in `yrby-rails`.


