### PR TITLE
Log causal-gap resyncs at info

### DIFF
--- a/CHANGELOG-rails.md
+++ b/CHANGELOG-rails.md
@@ -5,6 +5,15 @@ documented here. The
 format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Log each causal-gap resync at `info` (`[yrby] causal-gap resync ...`, with the
+  document key and `sync_log_context`). The reject path was otherwise silent, so
+  there was no way to see how often clients force a resync. Override
+  `sync_log_gap_resync` to change the level or silence it.
+
 ## [0.5.0] - 2026-08-05
 
 ### Added

--- a/lib/y/action_cable/sync.rb
+++ b/lib/y/action_cable/sync.rb
@@ -223,6 +223,29 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
       end
     end
 
+    # Log each causal-gap resync at info. The reject path is otherwise silent
+    # (it transmits a SyncStep1 and returns), so without this there's no way to
+    # see how often clients are sending updates ahead of their dependencies and
+    # forcing a resync. Names the document key and whatever sync_log_context
+    # returns, so frequency can be counted and traced per document.
+    #
+    # One line per forced resync: a client that keeps re-sending the same gapped
+    # update logs on every retry. That's the signal you want, but it can be
+    # chatty; override this method to change the level or silence it.
+    def sync_log_gap_resync
+      logger.info do
+        parts = ["key=#{@sync_key.inspect}"]
+        # A broken context hook must surface, not take down frame handling.
+        context = begin
+          sync_log_context
+        rescue StandardError => e
+          "log-context-error=#{e.class}"
+        end
+        parts << context if context
+        "[yrby] causal-gap resync (update depends on a prior update the store hasn't seen): #{parts.join(" ")}"
+      end
+    end
+
     # This concern acks updates as durably recorded, so it must have both a
     # loader (to rebuild the doc and detect causal gaps) and a recorder (to
     # actually persist before acking). Fail closed rather than silently acking
@@ -283,6 +306,7 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
         # heals as one complete delta.
         unless doc.update_ready?(update)
           sync_request_resync(doc)
+          sync_log_gap_resync
           return :gap
         end
 

--- a/test/sync_test.rb
+++ b/test/sync_test.rb
@@ -211,6 +211,22 @@ class SyncTest < Minitest::Test
     assert_operator transmits.length, :>, 1, "gapped update should trigger a SyncStep1 resync"
   end
 
+  def test_gap_resync_is_logged
+    logged = []
+    helper = helper_for
+    helper.logger = capturing_logger(logged)
+    helper.define_singleton_method(:sync_log_context) { "user=42" }
+
+    # A gapped update (U3 with no U1/U2 in the store) forces a resync.
+    helper.sync_receive(update_message(YjsFixtures::CausalChain::U3, id: 1), "doc-key")
+
+    resync = logged.find { |lvl, msg| lvl == :info && msg.include?("causal-gap resync") }
+
+    assert resync, "each forced resync is logged at info so its frequency is observable"
+    assert_includes resync.last, "doc-key", "the log names the document"
+    assert_includes resync.last, "user=42", "and includes sync_log_context"
+  end
+
   def test_gap_heals_after_client_resyncs
     store = []
     helper = helper_for(store: store)


### PR DESCRIPTION
Logs each causal-gap resync at `info` so resync frequency is visible in production.

When an update arrives before its causal dependencies are in the store, the concern asks the client to resync (`update_ready?` is false → `sync_request_resync` transmits a SyncStep1 → returns `:gap`). That path had no logging, so there was no way to tell how often it fires. `sync_log_gap_resync` now logs one line per forced resync:

```
[yrby] causal-gap resync (update depends on a prior update the store hasn't seen): key="doc-123" user=42
```

It names the document key and whatever `sync_log_context` returns, so the frequency can be counted and traced per document, and grepped with `[yrby] causal-gap resync`.

It logs once per forced resync, so a client that keeps re-sending the same gapped update logs on every retry: the signal you want, but it can be chatty under a persistently-gapped or poisoned client. Override `sync_log_gap_resync` to change the level or silence it.

Adds one test asserting a gapped update logs at `info` with the document key and `sync_log_context`. Full suite: 27 runs, 0 failures; rubocop clean.

