### PR TITLE
Y::Lexxy renders in-flight upload placeholders to nothing

### DIFF
--- a/lib/y/lexxy.rb
+++ b/lib/y/lexxy.rb
@@ -85,6 +85,13 @@ module Y
       tag.match?(/\A[a-zA-Z][a-zA-Z0-9-]*\z/) ? tag : "action-text-attachment"
     end
 
+    # An in-flight upload placeholder. Only the uploader's browser can
+    # complete it, so it is never finished content -- materialized output
+    # (Action Text bodies, search text) must not carry it.
+    def self.pending_upload(_node)
+      ""
+    end
+
     # A stored nil (unset) is skipped; a stored empty string still emits.
     def self.attachment_attr(node, html_name, stored)
       return "" if node.attrs[stored].nil?
@@ -103,6 +110,7 @@ module Y
       "tablecell" => { contains: :blocks, render: method(:table_cell) },
       "listitem" => { contains: :blocks, render: method(:list_item) },
       "action_text_attachment" => method(:upload),
+      "action_text_attachment_upload" => method(:pending_upload),
       "custom_action_text_attachment" => method(:mention)
     }.freeze
 

--- a/test/rendering_rules_test.rb
+++ b/test/rendering_rules_test.rb
@@ -156,6 +156,11 @@ class RenderingRulesTest < Minitest::Test
     assert_includes html, "attachment-gallery--3", "untouched Lexxy rules still apply"
   end
 
+  def test_pending_upload_nodes_render_to_nothing
+    assert_equal "", Y::Lexxy::NODES["action_text_attachment_upload"].call(nil),
+                 "an in-flight upload placeholder must not reach materialized output"
+  end
+
   def test_the_block_form_registers_declarative_callback_and_mark_rules
     html = Y::ProseMirror.new(prosemirror_doc) do |rules|
       rules.node "blockquote", tag: "aside", attrs: { "class" => "quote" }, contains: :blocks


### PR DESCRIPTION
An `action_text_attachment_upload` node is a provisional placeholder only the uploader's browser can complete. When a document is materialized — an Action Text body, search text — that placeholder is never finished content: a collaborator's abandoned upload would render a dead placeholder into every consumer's HTML.

`Y::Lexxy` now maps the type to an empty render. Finished attachments (`action_text_attachment`) are unaffected.

Context: lexxy-realtime removes a dying page's own upload placeholders (jpcamara/lexxy-realtime#10) and the structural fix is deferred upload insertion in Lexxy itself (jpcamara/lexxy#3); this guards the materialized output for any placeholder that slips through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TeaovH2jyHARHJSyQ8Afo
