### PR TITLE
Encrypted document storage: Y::EncryptedDocument

### DIFF
--- a/CHANGELOG-rails.md
+++ b/CHANGELOG-rails.md
@@ -5,6 +5,21 @@ documented here. The
 format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `Y::EncryptedDocument` / `Y::EncryptedDocumentUpdate`: document storage
+  encrypted with Active Record encryption (`state` and update payloads),
+  on the same tables — the class you access through decides the
+  cryptography, the way `ActionText::EncryptedRichText` does. Point a
+  channel's `on_load`/`on_change` (or a record association) at
+  `Y::EncryptedDocument` and configure the app's encryption keys. Keep
+  one access path per document: rows written encrypted read back as
+  ciphertext through the plain classes. Ciphertext is larger than the
+  plaintext, so the effective payload cap is roughly three quarters of
+  the column limit.
+
 ## [0.4.0] - 2026-08-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -492,6 +492,13 @@ The models ship in the gem, the way Action Text owns
   quarantined until they heal rather than compacted into state or
   deleted. Destroying a document deletes its updates with it.
 
+Encrypted storage: `Y::EncryptedDocument` stores `state` and update
+payloads through Active Record encryption on the same tables, the way
+`ActionText::EncryptedRichText` does — point the channel's
+`on_load`/`on_change` at it instead and configure your app's encryption
+keys. Use one access path per document: rows written encrypted read back
+as ciphertext through the plain classes.
+
 The migration creates `y_documents` and `y_document_updates`. To rename
 them, edit the generated migration and point `Y::Document.table_name` /
 `Y::DocumentUpdate.table_name` at the new names in an initializer.

--- a/app/models/y/document.rb
+++ b/app/models/y/document.rb
@@ -119,12 +119,7 @@ class Y::Document < ActiveRecord::Base
   # healed by a newer tail row is served immediately instead of waiting
   # for the next compaction.
   def load_state
-    # The tail class comes from the association reflection (not the
-    # association itself, whose cache could serve a stale tail) so a
-    # subclass swapping in encrypted rows reads them through the class
-    # that can decrypt them.
-    tail = self.class.reflect_on_association(:updates).klass
-               .where(document_id: id).pluck(:payload)
+    tail = updates.reset.pluck(:payload) # reset: never a cached tail
     snapshot = self.class.where(id: id).pick(:state)
     return snapshot if tail.empty?
 

--- a/app/models/y/document.rb
+++ b/app/models/y/document.rb
@@ -119,7 +119,12 @@ class Y::Document < ActiveRecord::Base
   # healed by a newer tail row is served immediately instead of waiting
   # for the next compaction.
   def load_state
-    tail = Y::DocumentUpdate.where(document_id: id).pluck(:payload)
+    # The tail class comes from the association reflection (not the
+    # association itself, whose cache could serve a stale tail) so a
+    # subclass swapping in encrypted rows reads them through the class
+    # that can decrypt them.
+    tail = self.class.reflect_on_association(:updates).klass
+               .where(document_id: id).pluck(:payload)
     snapshot = self.class.where(id: id).pick(:state)
     return snapshot if tail.empty?
 

--- a/app/models/y/encrypted_document.rb
+++ b/app/models/y/encrypted_document.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# A document whose stored bytes are encrypted with Active Record encryption
+# (state here, update payloads via Y::EncryptedDocumentUpdate). Same tables
+# as Y::Document — the class you access through decides the cryptography,
+# the way ActionText::EncryptedRichText does for rich text. Keep one access
+# path per document: rows written encrypted read back as ciphertext through
+# the plain classes.
+#
+# Requires the app to configure Active Record encryption keys. Ciphertext
+# is larger than the plaintext (a serialized envelope around Base64), so
+# the effective payload cap drops to roughly three quarters of the column
+# limit.
+class Y::EncryptedDocument < Y::Document
+  has_many :updates, class_name: "Y::EncryptedDocumentUpdate",
+                     foreign_key: :document_id, dependent: :delete_all,
+                     inverse_of: :document
+
+  encrypts :state
+end

--- a/app/models/y/encrypted_document_update.rb
+++ b/app/models/y/encrypted_document_update.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# The encrypted tail row: Y::DocumentUpdate with the payload encrypted.
+# Written and read through Y::EncryptedDocument's updates association.
+class Y::EncryptedDocumentUpdate < Y::DocumentUpdate
+  belongs_to :document, class_name: "Y::EncryptedDocument"
+
+  encrypts :payload
+end

--- a/lib/yrby/rails/version.rb
+++ b/lib/yrby/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Yrby
   module Rails
-    VERSION = "0.4.0"
+    VERSION = "0.5.0"
   end
 end

--- a/test/encrypted_document_test.rb
+++ b/test/encrypted_document_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "fixtures/yjs_fixtures"
+require_relative "support/active_record"
+require_relative "../app/models/y/document"
+require_relative "../app/models/y/document_update"
+require_relative "../app/models/y/encrypted_document"
+require_relative "../app/models/y/encrypted_document_update"
+
+# Y::EncryptedDocument stores state and payloads through Active Record
+# encryption on the same tables as Y::Document. The whole storage design
+# (append, load, compaction, record binding) must behave identically, and
+# the raw columns must hold ciphertext.
+class EncryptedDocumentTest < Minitest::Test
+  CLIENT_ONE = YjsFixtures::TwoDocsMerged::DOC1_UPDATE
+  CLIENT_TWO = YjsFixtures::TwoDocsMerged::DOC2_UPDATE
+
+  class Page < ActiveRecord::Base
+    self.table_name = "pages"
+  end
+
+  def setup
+    Y::DocumentUpdate.delete_all
+    Y::Document.delete_all
+    Page.delete_all
+  end
+
+  def read_back(state)
+    doc = Y::Doc.new
+    doc.apply_update(state)
+    doc.read_text("content")
+  end
+
+  def test_append_and_load_state_round_trip
+    Y::EncryptedDocument.append("room-1", CLIENT_ONE)
+    Y::EncryptedDocument.append("room-1", CLIENT_TWO)
+
+    assert_equal "from doc1from doc2", read_back(Y::EncryptedDocument.load_state("room-1"))
+  end
+
+  def test_payloads_are_ciphertext_at_rest
+    Y::EncryptedDocument.append("room-1", CLIENT_ONE)
+
+    raw = Y::Document.connection.select_value("SELECT payload FROM y_document_updates LIMIT 1")
+
+    refute_equal CLIENT_ONE, raw, "raw column must not hold the plaintext delta"
+    assert_includes raw, '"p":', "expected the Active Record encryption envelope"
+  end
+
+  def test_compaction_round_trips_and_state_is_ciphertext_at_rest
+    document = Y::EncryptedDocument.locate!("room-1")
+    document.append(CLIENT_ONE)
+    document.append(CLIENT_TWO)
+    before = read_back(document.load_state)
+
+    document.compact!
+
+    assert_equal 0, document.updates.count, "tail compacted"
+    assert_equal before, read_back(document.load_state)
+
+    raw = Y::Document.connection.select_value("SELECT state FROM y_documents LIMIT 1")
+
+    refute_nil raw
+    assert_includes raw, '"p":', "expected the Active Record encryption envelope"
+  end
+
+  def test_load_state_returns_decrypted_state_verbatim_when_the_tail_is_empty
+    document = Y::EncryptedDocument.locate!("room-1")
+    document.append(CLIENT_ONE)
+    document.compact!
+
+    assert_equal "from doc1", read_back(document.load_state)
+  end
+
+  def test_for_binds_records_like_the_plain_class
+    page = Page.create!
+    document = Y::EncryptedDocument.for(page, :body)
+
+    assert_instance_of Y::EncryptedDocument, document
+    assert_equal page, document.record
+    assert_equal "encrypted_document_test/page/#{page.id}/body", document.key
+    assert_equal document, Y::EncryptedDocument.for(page, :body)
+  end
+
+  def test_the_plain_class_reads_an_encrypted_row_as_ciphertext
+    # One access path per document: this documents what mixing them does.
+    document = Y::EncryptedDocument.locate!("room-1")
+    document.append(CLIENT_ONE)
+    document.compact!
+
+    refute_equal Y::EncryptedDocument.load_state("room-1"),
+                 Y::Document.load_state("room-1"),
+                 "the plain class must not silently decrypt"
+  end
+end

--- a/test/support/active_record.rb
+++ b/test/support/active_record.rb
@@ -9,6 +9,12 @@ unless defined?(YRBY_AR_BOOTED)
   require "active_record"
 
   ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+  # Test-only keys so the encrypted model variants can round-trip.
+  ActiveRecord::Encryption.configure(
+    primary_key: "test-primary-key" * 2,
+    deterministic_key: "test-deterministic-key" * 2,
+    key_derivation_salt: "test-key-derivation-salt" * 2
+  )
   ActiveRecord::Schema.verbose = false
   ActiveRecord::Schema.define do
     # The gem-owned models, as yrby:tables migrates them.


### PR DESCRIPTION
## Summary

- `Y::EncryptedDocument` / `Y::EncryptedDocumentUpdate`: document storage encrypted with Active Record encryption (`state` and update payloads), on the same tables as the plain classes.
- Follows the `ActionText::EncryptedRichText` pattern: the class you access through decides the cryptography — no schema change, encryption chosen per access path. A channel opts in by pointing `on_load`/`on_change` at `Y::EncryptedDocument`; a record association opts in with `class_name: "Y::EncryptedDocument"`.
- `Y::Document#load_state` now resolves the tail class through the `updates` association reflection (still cache-proof), so the encrypted subclass reads payload rows through the class that can decrypt them.
- Requires app-configured Active Record encryption keys. Ciphertext is larger than plaintext, so the effective payload cap is roughly three quarters of the column limit. One access path per document: rows written encrypted read back as ciphertext through the plain classes (covered by a test documenting exactly that).

## Tests

Six new tests: append/load round trip, ciphertext-at-rest assertions on both raw columns, compaction round trip, `.for` record binding on the subclass, and the mixed-access-path behavior. Existing document suite unchanged and green.