### PR TITLE
Run README Ruby examples in the test suite

### DIFF
--- a/packages/client/test/readme_examples.test.js
+++ b/packages/client/test/readme_examples.test.js
@@ -1,0 +1,47 @@
+// Checks the README's ```js examples against the built package: every
+// example must parse as a module, and every name imported from
+// "yrby-client" must exist in the real exports. Runs after `npm run
+// build` (the test script builds first), so dist/ is present.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const readme = readFileSync(join(root, "README.md"), "utf8");
+const blocks = [...readme.matchAll(/^```js\n([\s\S]*?)^```/gm)].map((m) => m[1]);
+
+test("README has js examples", () => {
+  assert.ok(blocks.length >= 3, `extraction found only ${blocks.length} blocks`);
+});
+
+test("README js examples parse as modules", () => {
+  const dir = mkdtempSync(join(tmpdir(), "readme-js-"));
+  try {
+    blocks.forEach((block, i) => {
+      const file = join(dir, `example_${i}.mjs`);
+      writeFileSync(file, block);
+      const check = spawnSync(process.execPath, ["--check", file], { encoding: "utf8" });
+      assert.equal(check.status, 0, `example ${i + 1} failed to parse:\n${check.stderr}\n${block}`);
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("names imported from yrby-client exist in the real exports", async () => {
+  const exported = new Set(Object.keys(await import("../dist/index.js")));
+  const imported = new Set();
+  for (const block of blocks) {
+    for (const m of block.matchAll(/import\s*\{([^}]+)\}\s*from\s*["']yrby-client["']/g)) {
+      m[1].split(",").forEach((name) => imported.add(name.trim().split(/\s+as\s+/)[0]));
+    }
+  }
+  assert.ok(imported.size >= 1, "no yrby-client imports found in examples");
+  for (const name of imported) {
+    assert.ok(exported.has(name), `README imports { ${name} } from yrby-client, which exports: ${[...exported].join(", ")}`);
+  }
+});

--- a/test/readme_examples_test.rb
+++ b/test/readme_examples_test.rb
@@ -24,7 +24,7 @@ class ReadmeExamplesTest < Minitest::Test
 
   FIXTURES = File.expand_path("../ext/yrby/crates/lexical-html/src/fixtures", __dir__)
 
-  PRELUDE = <<~RUBY
+  PRELUDE = <<~RUBY.freeze
     doc = Y::Doc.new
     doc.apply_update(File.binread(File.join(#{FIXTURES.inspect}, "lexxy_full.bin")))
     ydoc = doc

--- a/test/readme_examples_test.rb
+++ b/test/readme_examples_test.rb
@@ -16,11 +16,10 @@ require_relative "../app/models/y/encrypted_document_update"
 class ReadmeExamplesTest < Minitest::Test
   README = File.expand_path("../README.md", __dir__)
 
-  # Configuration fragments and intentionally illustrative blocks.
-  SKIP = [
-    /\A# Gemfile/,
-    /\Agem "/
-  ].freeze
+  # Gemfile fragments: every non-blank line is a comment or a gem call.
+  def gemfile_fragment?(block)
+    block.lines.map(&:strip).reject(&:empty?).all? { |l| l.start_with?("#", "gem \"") }
+  end
 
   FIXTURES = File.expand_path("../ext/yrby/crates/lexical-html/src/fixtures", __dir__)
 
@@ -58,7 +57,7 @@ class ReadmeExamplesTest < Minitest::Test
   def test_readme_ruby_examples
     executed = 0
     File.read(README).scan(/^```ruby\n(.*?)^```/m).map(&:first).each_with_index do |block, i|
-      next if SKIP.any? { |pattern| block.match?(pattern) }
+      next if gemfile_fragment?(block)
 
       executed += 1
       container = Module.new

--- a/test/readme_examples_test.rb
+++ b/test/readme_examples_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "fixtures/yjs_fixtures"
+require_relative "support/active_record"
+require "y/action_cable"
+require_relative "../app/models/y/document"
+require_relative "../app/models/y/document_update"
+require_relative "../app/models/y/encrypted_document"
+require_relative "../app/models/y/encrypted_document_update"
+
+# Runs the ```ruby blocks from README.md against the real gem, so an
+# example that drifts from the API fails the suite. Each block evaluates
+# in its own anonymous module with a prelude supplying the names examples
+# use without declaring (doc, key, a store, channel scaffolding).
+class ReadmeExamplesTest < Minitest::Test
+  README = File.expand_path("../README.md", __dir__)
+
+  # Configuration fragments and intentionally illustrative blocks.
+  SKIP = [
+    /\A# Gemfile/,
+    /\Agem "/
+  ].freeze
+
+  FIXTURES = File.expand_path("../ext/yrby/crates/lexical-html/src/fixtures", __dir__)
+
+  PRELUDE = <<~RUBY
+    doc = Y::Doc.new
+    doc.apply_update(File.binread(File.join(#{FIXTURES.inspect}, "lexxy_full.bin")))
+    ydoc = doc
+    key = "readme-example-\#{name}"
+    Y::Document.append(key, YjsFixtures::TwoDocsMerged::DOC1_UPDATE)
+    update = YjsFixtures::TwoDocsMerged::DOC2_UPDATE
+    update_bytes = update
+    sv = doc.encode_state_vector
+    data = Y::Doc.new.sync_step1
+    frame = Y.wrap_update(update)
+    note = Struct.new(:content).new
+    store = Class.new do
+      def replay(_id) = YjsFixtures::TwoDocsMerged::DOC1_UPDATE
+      def record!(_id, _update) = nil
+      def load(_id) = nil
+    end.new
+    module ApplicationCable
+      class Channel
+        def self.identifier = nil
+        def params = {}
+        def reject = nil
+      end
+    end
+  RUBY
+
+  def setup
+    Y::DocumentUpdate.delete_all
+    Y::Document.delete_all
+  end
+
+  def test_readme_ruby_examples
+    executed = 0
+    File.read(README).scan(/^```ruby\n(.*?)^```/m).map(&:first).each_with_index do |block, i|
+      next if SKIP.any? { |pattern| block.match?(pattern) }
+
+      executed += 1
+      container = Module.new
+      container.module_eval(PRELUDE + block, "README.md:example_#{i + 1}")
+    rescue Exception => e # rubocop:disable Lint/RescueException -- report which example broke
+      flunk "README example #{i + 1} raised #{e.class}: #{e.message}\n#{block}"
+    end
+
+    assert_operator executed, :>=, 10, "extraction found too few runnable examples"
+  end
+end


### PR DESCRIPTION
Every ```ruby block in README.md now executes against the real gem in `rake test`, covering both the core API docs and the yrby-rails sections. Each block runs in its own anonymous module with a short prelude for the names examples use without declaring (`doc` loaded from a captured fixture, `sv`, `frame`, a store stub, channel scaffolding). Gemfile fragments are skipped by pattern, and the test fails when extraction finds too few blocks, so a broken parser cannot silently pass.

Verified it bites: renaming a method in an example fails the suite with the exact block quoted. The extracted Rust crates already doctest their READMEs via `include_str!`; this brings the Ruby half to parity. Companion PR on lexxy-realtime: jpcamara/lexxy-realtime#14 (Ruby blocks executed, JS blocks compile-checked against src).