### PR TITLE
Point the install instructions at yrby-rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ and [Lexxy](https://www.npmjs.com/package/lexxy-realtime).
 Install the gem and npm package:
 
 ```
-gem install yrby-actioncable # depends on yrby
+gem install yrby-rails # depends on yrby
 npm install yrby-client
 ```
 
@@ -64,7 +64,7 @@ guarantees, correctness, and thread safety.
 Towards that goal, `yrby` adds opinionated defaults on top of normal Yjs syncing:
 
 - Built-in update acknowledgement: the `ActionCableProvider` in `yrby-client` will continue to
-  send updates until an ack is received from the server. [`yrby-actioncable`](https://rubygems.org/gems/yrby-actioncable)
+  send updates until an ack is received from the server. [`yrby-rails`](https://rubygems.org/gems/yrby-rails)
   only sends an ack when applying an update is successful. The goal is at-least-once delivery,
   and because CRDTs are idempotent a duplicate update is effectively a no-op.
 - Gap detection in document updates: before applying an update and sending an ack to the client,


### PR DESCRIPTION
Two README references survived the gem rename: the `gem install` line under Usage and a prose link to the RubyGems page. Both named `yrby-actioncable`, which stopped at 0.3.1 when the gem became `yrby-rails` (now 0.5.0), so a reader following the README installed the abandoned name.

The "Formerly yrby-actioncable; that name stops at 0.3.1" note in the Gemfile example keeps the old name deliberately and is unchanged.