### PR TITLE
Use Y::ActionCable in the docs and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,8 +508,7 @@ answered, and they can point at anything.
 
 `include Y::ActionCable` (from the `yrby-rails` gem) is the channel
 integration: the y-websocket protocol (document sync +
-awareness/presence) over ActionCable. (`include Y::ActionCable::Sync`
-keeps working and has the same effect.)
+awareness/presence) over ActionCable.
 
 ```ruby
 # app/channels/document_channel.rb

--- a/examples/actioncable-demo/README.md
+++ b/examples/actioncable-demo/README.md
@@ -5,7 +5,7 @@ server. The Y.js sync protocol and awareness (shared cursors and presence) run
 natively in Ruby through [yrby](../..).
 
 ```
-Browser (Tiptap + Yjs + yrby-client) ⇄ ActionCable ⇄ DocumentChannel (Y::ActionCable::Sync)
+Browser (Tiptap + Yjs + yrby-client) ⇄ ActionCable ⇄ DocumentChannel (Y::ActionCable)
 ```
 
 The server can read the document too. `GET /docs/:id/content` returns the
@@ -176,7 +176,7 @@ is the whole integration:
 
 ```ruby
 class DocumentChannel < ApplicationCable::Channel
-  include Y::ActionCable::Sync
+  include Y::ActionCable
 
   on_load  { |key| Store.current.replay(key) }
   on_change { |key, update| Store.current.record(key, update) }

--- a/examples/actioncable-demo/app/channels/document_channel.rb
+++ b/examples/actioncable-demo/app/channels/document_channel.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 # Collaborative document channel. The whole y-websocket protocol is the three
-# lines of Y::ActionCable::Sync below. Documents are loaded from and
+# lines of Y::ActionCable below. Documents are loaded from and
 # recorded to Store.current; ActionCable process memory is not authoritative.
 class DocumentChannel < ApplicationCable::Channel
-  include Y::ActionCable::Sync
+  include Y::ActionCable
 
   on_load  { |key| Store.current.replay(key) }
   on_change { |key, update| Store.current.record(key, update) }

--- a/lib/y/action_cable/sync.rb
+++ b/lib/y/action_cable/sync.rb
@@ -16,7 +16,7 @@ module Y::ActionCable # rubocop:disable Style/ClassAndModuleChildren
   #
   # Example:
   #   class DocumentChannel < ApplicationCable::Channel
-  #     include Y::ActionCable::Sync
+  #     include Y::ActionCable
   #
   #     on_load { |key| Document.find_by(key: key)&.content }
   #     # on_change runs in the channel instance's context, so instance methods

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -87,7 +87,7 @@ deferred one microtask so that removal flushes first) and tears down the
 your own `Awareness`, drop down to `YProtocolSession`, which leaves it for you to
 own.)
 
-On the server, include `Y::ActionCable::Sync` in a channel named
+On the server, include `Y::ActionCable` in a channel named
 `DocumentChannel` (the [`yrby-actioncable`](https://rubygems.org/gems/yrby-actioncable)
 gem). The server subscribes document broadcasts and AnyCable awareness whispers
 on separate streams, so the document stream is not whisper-enabled. Need a
@@ -166,7 +166,7 @@ Document delivery stays queued and ack-tracked for the lifetime of the session.
 ## How it fits
 
 The server counterpart — ack *generation*, gap detection, record-before-distribute
-— is the `yrby-actioncable` gem's `Y::ActionCable::Sync`. This package
+— is the `yrby-rails` gem's `Y::ActionCable`. This package
 is the client half of the same protocol.
 
 ## License


### PR DESCRIPTION
`Y::ActionCable` forwards to `Y::ActionCable::Sync`, and the short form is what a channel should say. Docs and examples now use it consistently:

- `examples/actioncable-demo`: the channel itself and the README (including the architecture diagram). The demo e2e runs this channel in CI, so the short form is now exercised end to end on every build.
- `packages/client/README.md`: the server-side instruction, which also still called the Rails gem `yrby-actioncable` (it is `yrby-rails`).
- The usage example in `Y::ActionCable::Sync`'s own doc comment.
- The main README, which noted in an aside that the long form keeps working. The changelog already records that, so the aside is gone and no doc shows the long spelling as something to write.

Left alone deliberately: the CHANGELOG entries (history), `CONTRIBUTING.md`'s file-layout line and the runtime error messages (both name where the module actually lives), and the tests (they assert the two spellings resolve to the same concern).