### PR TITLE
Serve lossless state from Y::Document.load_state

### DIFF
--- a/CHANGELOG-rails.md
+++ b/CHANGELOG-rails.md
@@ -5,6 +5,17 @@ documented here. The
 format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `Y::Document.load_state` serves lossless state (`encode_state_as_update`).
+  It previously served gap-free state, so a client joining while a gap was
+  open never received the parked edit and could not heal it until its next
+  handshake. The quarantined row was always preserved; now the pending
+  struct rides along in served state and a mid-gap joiner heals the moment
+  the missing dependency arrives.
+
 ## [0.6.0] - 2026-08-11
 
 ### Changed

--- a/app/models/y/document.rb
+++ b/app/models/y/document.rb
@@ -113,11 +113,11 @@ class Y::Document < ActiveRecord::Base
   # compaction committing between the two reads then hands us rows already
   # folded into the fresh snapshot, an idempotent double-apply, where
   # the reverse order could pair a pre-compaction snapshot with an empty
-  # tail and omit committed changes. Quarantined rows are applied too:
-  # the output goes through compacted_state_update, which is gap-free by
-  # construction, so an unhealed gap contributes nothing while a gap
-  # healed by a newer tail row is served immediately instead of waiting
-  # for the next compaction.
+  # tail and omit committed changes. Quarantined rows are applied too,
+  # and the output is lossless (encode_state_as_update): an unhealed gap
+  # rides along as a pending struct, so a peer loaded mid-gap holds the
+  # parked edit and heals it the moment the missing dependency arrives,
+  # while a gap healed by a newer tail row is served merged immediately.
   def load_state
     tail = updates.reset.pluck(:payload) # reset: never a cached tail
     snapshot = self.class.where(id: id).pick(:state)
@@ -126,7 +126,7 @@ class Y::Document < ActiveRecord::Base
     doc = Y::Doc.new
     doc.apply_update(snapshot) if snapshot
     tail.each { |payload| doc.apply_update(payload) }
-    doc.compacted_state_update
+    doc.encode_state_as_update
   end
 
   # Compact the tail into state. The row lock serializes racing

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -205,6 +205,21 @@ class DocumentTest < Minitest::Test
                  "one clean row is below the threshold; quarantined rows don't trigger"
   end
 
+  def test_load_state_preserves_an_unhealed_gap_so_a_peer_can_heal_it
+    document = Y::Document.locate!("room-1")
+    document.append(YjsFixtures::Gap::DEPENDENT)
+    document.compact! # quarantined
+
+    peer = Y::Doc.new
+    peer.apply_update(Y::Document.load_state("room-1"))
+
+    assert_predicate peer, :pending?, "the parked edit rides along in served state"
+
+    peer.apply_update(YjsFixtures::Gap::FIRST)
+
+    assert_equal "ab", peer.read_text("notepad"), "the peer heals without another load"
+  end
+
   def test_a_healed_gap_is_served_immediately_and_compacts_clean
     document = Y::Document.locate!("room-1")
     document.append(YjsFixtures::Gap::DEPENDENT)


### PR DESCRIPTION
Y::Document.load_state built the merged document and returned
compacted_state_update, which is gap-free by construction. The
quarantined row was preserved in the table, but the served bytes
dropped the parked struct: a client joining while a gap was open never
received the parked edit, and when the missing dependency arrived it
could not heal until its next handshake.

load_state now returns encode_state_as_update, so an unhealed gap rides
along in served state as a pending struct and a mid-gap joiner heals
the moment the missing dependency arrives. This also matches the store
contract in the README: on_load must return state that preserves
pending. Compaction is untouched; state snapshots stay gap-free.

New test: a peer built from load_state during an open gap holds the
pending struct and heals to the full text when the dependency is
applied, with no second load.