### PR TITLE
Fix stale yrby-actioncable references and the core floor rationale

### DIFF
--- a/lib/y.rb
+++ b/lib/y.rb
@@ -20,5 +20,5 @@ require_relative "y/decoder"
 module Y
   # Doc, Error, and the protocol module functions are defined in the Rust
   # extension. The ActionCable integration (Y::ActionCable::Sync) lives in the
-  # separate `yrby-actioncable` gem; require "y/action_cable".
+  # `yrby-rails` gem; require "y/action_cable".
 end

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -88,7 +88,7 @@ your own `Awareness`, drop down to `YProtocolSession`, which leaves it for you t
 own.)
 
 On the server, include `Y::ActionCable` in a channel named
-`DocumentChannel` (the [`yrby-actioncable`](https://rubygems.org/gems/yrby-actioncable)
+`DocumentChannel` (the [`yrby-rails`](https://rubygems.org/gems/yrby-rails)
 gem). The server subscribes document broadcasts and AnyCable awareness whispers
 on separate streams, so the document stream is not whisper-enabled. Need a
 different transport or framing? Drop down to `YProtocolSession` and supply your

--- a/yrby-rails.gemspec
+++ b/yrby-rails.gemspec
@@ -38,8 +38,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">= 7.1"
   spec.add_dependency "base64", "~> 0.2"
   spec.add_dependency "railties", ">= 7.1"
-  # 0.3.1's update_ready? is exact for cross-client gaps; the channel gates
-  # recording on it, and an older core could ack-and-drop real content.
+  # 0.7.0's handle_sync_message serves full state, pending included; the
+  # channel's serve path and the store contract both depend on it.
   spec.add_dependency "yrby", ">= 0.7.0"
   # The concern calls ActionCable.server directly, and railties doesn't
   # depend on actioncable, so declare it. activesupport comes along with


### PR DESCRIPTION
Three doc fixes from an alignment audit:

- packages/client/README.md pointed server setup at the retired
  yrby-actioncable gem; the channel ships in yrby-rails. The npm page
  shows the stale text until the next yrby-client publish picks this up.
- lib/y.rb's module comment said the ActionCable integration lives in
  the separate yrby-actioncable gem; same fix.
- yrby-rails.gemspec's comment above the yrby floor still justified it
  with 0.3.1's update_ready? gate, which the channel no longer has. The
  0.7.0 floor exists because handle_sync_message serves full state,
  pending included, and the serve path and store contract depend on it.