### PR TITLE
Demo: lexxy-realtime 0.6.0 and Lexxy 0.9.29

### DIFF
--- a/examples/actioncable-demo/frontend/bun.lock
+++ b/examples/actioncable-demo/frontend/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "actioncable-demo-frontend",
       "dependencies": {
-        "@37signals/lexxy": "^0.9",
+        "@37signals/lexxy": "^0.9.29",
         "@codemirror/lang-javascript": "^6.2.2",
         "@codemirror/state": "^6.4.1",
         "@codemirror/view": "^6.26.0",
@@ -21,7 +21,7 @@
         "@tiptap/starter-kit": "^2.11.0",
         "codemirror": "^6.0.1",
         "lexical": "^0.44",
-        "lexxy-realtime": "^0.2.1",
+        "lexxy-realtime": "^0.6.0",
         "lib0": "^0.2.97",
         "prosemirror-keymap": "^1.2.2",
         "rhino-editor": "^0.18.3",
@@ -56,7 +56,7 @@
     },
   },
   "packages": {
-    "@37signals/lexxy": ["@37signals/lexxy@0.9.23", "", { "dependencies": { "@lexical/clipboard": "^0.44.0", "@lexical/code": "^0.44.0", "@lexical/extension": "^0.44.0", "@lexical/history": "^0.44.0", "@lexical/html": "^0.44.0", "@lexical/link": "^0.44.0", "@lexical/list": "^0.44.0", "@lexical/markdown": "^0.44.0", "@lexical/plain-text": "^0.44.0", "@lexical/rich-text": "^0.44.0", "@lexical/selection": "^0.44.0", "@lexical/table": "^0.44.0", "@lexical/utils": "^0.44.0", "dompurify": "^3.3.0", "lexical": "^0.44.0", "marked": "^16.4.1", "prismjs": "^1.30.0" }, "peerDependencies": { "@rails/activestorage": ">= 7.0.0" }, "optionalPeers": ["@rails/activestorage"] }, "sha512-uRGUtFAdL+gMuHB1M5aT423ADlFxkMdS93E2sPed0cZF8+0f5lpGYcXxgUI43TlDsaicx+bk3DLvMv1ol+soCw=="],
+    "@37signals/lexxy": ["@37signals/lexxy@0.9.29", "", { "dependencies": { "@lexical/clipboard": "^0.44.0", "@lexical/code": "^0.44.0", "@lexical/extension": "^0.44.0", "@lexical/history": "^0.44.0", "@lexical/html": "^0.44.0", "@lexical/link": "^0.44.0", "@lexical/list": "^0.44.0", "@lexical/markdown": "^0.44.0", "@lexical/plain-text": "^0.44.0", "@lexical/rich-text": "^0.44.0", "@lexical/selection": "^0.44.0", "@lexical/table": "^0.44.0", "@lexical/utils": "^0.44.0", "dompurify": "^3.3.0", "lexical": "^0.44.0", "marked": "^16.4.1", "prismjs": "^1.30.0" }, "peerDependencies": { "@rails/activestorage": ">= 7.0.0" }, "optionalPeers": ["@rails/activestorage"] }, "sha512-xekobv7/0L0/nSt6BaP6U5TClN3n4U9BBEdytiHTGVN/TRdo9vO7uqLYSqtoWLg+1S5Mj/SD7aPFFqEJcVo5Xg=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
 
@@ -430,7 +430,7 @@
 
     "lexical": ["lexical@0.44.0", "", {}, "sha512-ReDUjRlFgkGoPWzvdjr7s16PUVpHATN+2NH2NiZs+PLlISTaIFFgKil2P467oP3Vg+XgmpDsUgmWZsFJTztYjg=="],
 
-    "lexxy-realtime": ["lexxy-realtime@0.2.1", "", { "peerDependencies": { "@37signals/lexxy": "^0.9", "@anycable/web": "*", "@lexical/yjs": "^0.44", "lexical": "^0.44", "y-protocols": "^1.0", "yjs": "^13.6" }, "optionalPeers": ["@anycable/web"] }, "sha512-qq+LIHAkQDHrlebulQ5OvBEG3aac08LvNyWBy81hOfo8Gx0wffTm9G2VnYKq4dlykRMnsS5FOU9muq2Z6ffXwA=="],
+    "lexxy-realtime": ["lexxy-realtime@0.6.0", "", { "dependencies": { "yrby-client": "^0.5.0" }, "peerDependencies": { "@37signals/lexxy": "^0.9.29", "@lexical/yjs": "^0.44", "lexical": "^0.44", "y-protocols": "^1.0", "yjs": "^13.6" } }, "sha512-a85cMf2ad0ghXE4lQbOFCgX+dQsWqjOrtG89tN4+qtPoUUCBZ3FUAxaGnpyuirsdbui92lHrhzuLvc0jemtn8g=="],
 
     "lib0": ["lib0@0.2.117", "", { "dependencies": { "isomorphic.js": "^0.2.4" }, "bin": { "0serve": "bin/0serve.js", "0gentesthtml": "bin/gentesthtml.js", "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js" } }, "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw=="],
 
@@ -609,6 +609,8 @@
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "cssstyle/rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
+
+    "lexxy-realtime/yrby-client": ["yrby-client@0.5.0", "", { "dependencies": { "lib0": "^0.2.117" }, "peerDependencies": { "y-protocols": "^1.0.5", "yjs": "^13.6.0" }, "optionalPeers": ["y-protocols", "yjs"] }, "sha512-04cX0ixPRGY401P60TMdg71xNOK48uBHJGTDM9hTnskertLql7eoxTxxxl8ZnthoG5EDAuGTfSl29fDNjwBAJA=="],
 
     "markdown-it/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 

--- a/examples/actioncable-demo/frontend/package.json
+++ b/examples/actioncable-demo/frontend/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@37signals/lexxy": "^0.9",
+    "@37signals/lexxy": "^0.9.29",
     "@codemirror/lang-javascript": "^6.2.2",
     "@codemirror/state": "^6.4.1",
     "@codemirror/view": "^6.26.0",
@@ -24,7 +24,7 @@
     "@tiptap-v3/extension-collaboration-caret": "npm:@tiptap/extension-collaboration-caret@^3.27",
     "codemirror": "^6.0.1",
     "lexical": "^0.44",
-    "lexxy-realtime": "^0.2.1",
+    "lexxy-realtime": "^0.6.0",
     "lib0": "^0.2.97",
     "prosemirror-keymap": "^1.2.2",
     "rhino-editor": "^0.18.3",


### PR DESCRIPTION
The demo's Lexxy page pinned lexxy-realtime ^0.2.1, four releases behind: before the element-managed wiring fix, collaborative attachments, first-open seeding, and the styled cursors. Bumps to ^0.6.0 with Lexxy at ^0.9.29 (the peer floor; earlier Lexxy throws at bind on 0.4.0+).

Verified locally against the published packages: the lexxy render e2e passes, the main demo e2e passes, and a two-browser check on the Lexxy page confirms the collaboration theme renders (caret class, rounded pill, injected stylesheet).