### PR TITLE
Cap the state column at 1 GB - 1 so Postgres migrates

### DIFF
--- a/CHANGELOG-rails.md
+++ b/CHANGELOG-rails.md
@@ -5,6 +5,17 @@ documented here. The
 format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- The `yrby:tables` migration template caps `y_documents.state` at
+  `1.gigabyte - 1` instead of `4.gigabytes - 1`. Postgres raises
+  `ArgumentError` for binary limits above 1 GB - 1, so `db:migrate` on a
+  fresh Postgres app failed. MySQL maps both values to `longblob`, and
+  SQLite ignores limits, so nothing changes there. Apps that already
+  migrated are unaffected.
+
 ## [0.6.1] - 2026-08-11
 
 ### Fixed

--- a/lib/generators/yrby/tables/tables_generator.rb
+++ b/lib/generators/yrby/tables/tables_generator.rb
@@ -10,10 +10,13 @@ module Yrby
     # yrby:install, and by other gems building on the same storage.
     #
     # Template notes (kept here, not in the emitted migration): state is
-    # 4.gigabytes - 1 (longblob on MySQL; a compacted snapshot is the whole
-    # document; a 16 MB cap would break compaction) and payload is
-    # 16.megabytes - 1 (one update can carry a big paste or a client's
-    # accumulated offline edits; the 64 KB default blob is too small).
+    # 1.gigabyte - 1 — the largest limit every adapter accepts. MySQL maps
+    # anything over 16 MB to longblob (a compacted snapshot is the whole
+    # document; a 16 MB cap would break compaction); Postgres raises above
+    # 1 GB - 1 and ignores the limit on bytea otherwise; SQLite ignores
+    # limits. Payload is 16.megabytes - 1 (one update can carry a big paste
+    # or a client's accumulated offline edits; the 64 KB default blob is
+    # too small).
     # The partial unique index's WHERE only keeps
     # key-only rows out of the index: uniqueness holds without it, since
     # unique indexes treat NULLs as distinct on every supported database,

--- a/lib/generators/yrby/tables/templates/create_y_tables.rb
+++ b/lib/generators/yrby/tables/templates/create_y_tables.rb
@@ -6,7 +6,7 @@ class CreateYTables < ActiveRecord::Migration<%= migration_version %>
       t.string :key, null: false, index: { unique: true }
       t.references :record, polymorphic: true, null: true, index: false
       t.string :name
-      t.binary :state, limit: 4.gigabytes - 1
+      t.binary :state, limit: 1.gigabyte - 1
       t.timestamps
       t.index %i[record_type record_id name], unique: true,
               where: "record_type IS NOT NULL",

--- a/test/install_generator_test.rb
+++ b/test/install_generator_test.rb
@@ -33,7 +33,9 @@ class InstallGeneratorTest < Rails::Generators::TestCase
       assert_match(":y_documents", migration)
       assert_match("t.string :key, null: false, index: { unique: true }", migration)
       assert_match("t.references :record, polymorphic: true, null: true", migration)
-      assert_match(/t\.binary :state, limit: 4\.gigabytes - 1/, migration)
+      # 1 GB - 1 is the largest limit every adapter accepts: Postgres
+      # raises above it; MySQL still maps it to longblob.
+      assert_match(/t\.binary :state, limit: 1\.gigabyte - 1/, migration)
       assert_match(":y_document_updates", migration)
       assert_match("t.references :document", migration)
       assert_match(/t\.binary :payload, null: false, limit: 16\.megabytes - 1/, migration)


### PR DESCRIPTION
The yrby:tables migration template set `t.binary :state, limit: 4.gigabytes - 1`. Postgres raises `ArgumentError: No binary type has byte size 4294967295` for binary limits above 1 GB - 1 (every Rails from 7.0 through 8.1), so `db:migrate` on a fresh Postgres app failed — including installs arriving through gems that invoke yrby:tables. Verified against a real Postgres: the old limit raises, the new one creates `bytea` cleanly.

`1.gigabyte - 1` is the largest limit every adapter accepts: MySQL maps anything over 16 MB to `longblob` (unchanged — the original value's intent), SQLite ignores limits, Postgres sits exactly at its cap. The payload column's 16 MB - 1 is under the cap and stays.

Apps that already migrated are unaffected; the generator comment and test track the new value.