### PR TITLE
Rewrite the renderer crates' README and crate-level docs in plain prose

### DIFF
--- a/ext/yrby/crates/html-core/README.md
+++ b/ext/yrby/crates/html-core/README.md
@@ -5,18 +5,19 @@ Internal core of
 [`prosemirror-yjs-html`](https://crates.io/crates/prosemirror-yjs-html):
 the per-node render rules and segmented HTML output they share.
 
-Don't depend on this crate directly. The renderer crates re-export its
-whole surface (`Rules`, `Segment`, `flatten`, and the rest), and it makes no
-stability promise of its own. It's a separate package only because published
-crates can't share a path dependency.
+Do not depend on this crate directly. The renderer crates re-export its
+entire surface (`Rules`, `Segment`, `flatten`, and the rest). This crate
+makes no API stability promises of its own. It is a separate package only
+because published crates cannot share a path dependency.
 
-Rules come in two tiers. A declarative rule (tag, attributes, text, content
-slot) compiles to `NodeRule`/`MarkRule` and renders inside the transaction.
-A callback rule defers to the caller: the renderer emits `Segment::Deferred`
-with the node's type, attributes as JSON, and its rendered children, and you
-splice the result in after the render returns. Your code never runs while
-the document is locked. Rules parse from one JSON document (`Rules::parse`),
-so the same format works for any binding.
+Rules come in two tiers. A declarative rule is a tag, attributes, text, and
+a content slot. It compiles to a `NodeRule` or `MarkRule` and renders inside
+the document transaction. A callback rule defers to the caller. The renderer
+emits `Segment::Deferred` entries with the node's type, its attributes as
+JSON, and its already-rendered children, and the caller splices the result
+in after the render returns. Application code never runs while the document
+is locked. Rules parse from one JSON document (`Rules::parse`), so the same
+format serves any binding.
 
 ## License
 

--- a/ext/yrby/crates/html-core/src/lib.rs
+++ b/ext/yrby/crates/html-core/src/lib.rs
@@ -1,21 +1,21 @@
-//! Custom render rules and segmented output — the extensibility core shared
-//! by both HTML renderers.
+//! The custom render rules and segmented output that both HTML renderers
+//! share.
 //!
-//! Callers register per-node rules. Two tiers:
+//! Callers register a rule per node. There are two tiers:
 //!
-//! - **Declarative rules** (tag, attributes, text, content slot) compile to
-//!   [`NodeRule`]/[`MarkRule`] here and render natively, inside the document
+//! - A declarative rule (tag, attributes, text, content slot) compiles to a
+//!   [`NodeRule`] or [`MarkRule`] and renders natively, inside the document
 //!   transaction, at full speed. This covers the tiptap-php `renderHTML`
 //!   shape: markup as data.
-//! - **Callback rules** defer to the caller. Rendering never runs app code
-//!   while the document is locked — the renderer emits [`Segment::Deferred`]
-//!   entries carrying the node's type, attributes (as JSON), and its
-//!   already-rendered children, and the caller fills them in after the
-//!   render returns. (In the Ruby gem, that caller is the app's block, run
-//!   once the transaction has closed and the GVL is held again.)
+//! - A callback rule defers to the caller. The renderer never runs
+//!   application code while the document is locked. It emits
+//!   [`Segment::Deferred`] entries with the node type, the attributes as
+//!   JSON, and the already-rendered children, and the caller fills them in
+//!   after the render returns. In the Ruby gem that caller is the app's
+//!   block, run once the transaction has closed and the GVL is held again.
 //!
-//! Rules arrive as one JSON document (see `parse`), so the same format
-//! serves any binding or caller.
+//! Rules arrive as one JSON document (see `parse`), so one format serves
+//! every binding and caller.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use yrs::{Any, Out, ReadTxn, Xml};

--- a/ext/yrby/crates/lexical-html/README.md
+++ b/ext/yrby/crates/lexical-html/README.md
@@ -1,10 +1,10 @@
 # lexical-yjs-html
 
-Renders a [Lexical](https://lexical.dev) document to HTML straight from its
-Yjs form, using [yrs](https://crates.io/crates/yrs). No browser, no Node. It
-handles core Lexical: paragraphs, headings, quotes, code blocks, lists,
-tables, links, and text formatting. The tests check output byte-for-byte
-against documents captured from a real editor.
+Renders a [Lexical](https://lexical.dev) document to HTML from its Yjs
+representation, using [yrs](https://crates.io/crates/yrs). It covers core
+Lexical: paragraphs, headings, quotes, code blocks, lists, tables, links, and
+the full text-format model. The tests pin the output byte-for-byte to
+fixtures captured from a live editor.
 
 ## Usage
 
@@ -14,8 +14,8 @@ lexical-yjs-html = "0.1"
 yrs = { version = "0.27", features = ["sync"] }
 ```
 
-Feed it a Yjs update. That is bytes from your store, a provider, or
-`Y.encodeStateAsUpdate` in the browser.
+The input is a Yjs update: bytes from a durable store, from a provider, or
+from `Y.encodeStateAsUpdate` in the browser.
 
 ```rust,no_run
 use yrs::updates::decoder::Decode;
@@ -36,13 +36,14 @@ let html = lexical_yjs_html::render(&txn, &fragment);
 ```
 
 One doc can hold several fragments. Pass the root name your editor binds.
-`render` returns `None` when the fragment isn't Lexical-shaped.
+`render` returns `None` when the fragment is not Lexical-shaped.
 
 ## Declarative rules
 
-For a node type the built-in schema doesn't know, write a rule: a tag,
-attribute templates, and a content slot. Declarative rules render in the
-transaction, no callback:
+A rule tells the renderer how to draw a node type the built-in schema does
+not know. A rule is a tag, attribute templates, and a content slot.
+Declarative rules render inside the document transaction. Nothing calls
+back into your code.
 
 ```rust,no_run
 use yrs::{Doc, Transact, ReadTxn};
@@ -69,21 +70,23 @@ let html = flatten(segments).into_html().expect("no callback rules");
 // <aside class="callout callout--warning">…</aside>
 ```
 
-An attribute template mixes literal parts (`lit`) with stored attributes
-(`ref`), and drops out when it resolves empty. `content` is `inline` for
-formatted text, `blocks` for child blocks, or `none` for a leaf; `inline`
-is the default. `void: true` drops the closing tag. Point a rule at a
-built-in type to override it. This crate has no marks tier. Lexical keeps
-formatting in the text model, and that renders on its own. For marks, use
-[`prosemirror-yjs-html`](https://crates.io/crates/prosemirror-yjs-html).
+An attribute template joins literal parts (`lit`) and stored-attribute
+references (`ref`). An attribute that resolves empty is omitted. `content`
+is `"inline"` for formatted text, `"blocks"` for child block nodes, or
+`"none"` for a leaf. `"inline"` is the default. `"void": true` skips the
+closing tag. A rule for a built-in type replaces how that type renders.
+This crate has no marks tier. Lexical keeps formatting inside its text
+model, and the renderer handles that natively.
+[`prosemirror-yjs-html`](https://crates.io/crates/prosemirror-yjs-html) has
+the marks side.
 
 ## Callback rules
 
-Some nodes need real work, like a database lookup. Mark the rule
-`callback` and the renderer hands them back to you. Deferred nodes come
-back as segments with their type, attributes as JSON, and rendered
-children. The render never runs your code. You splice the result in after
-it returns:
+A rule marked `callback` hands the node to your code. Use it for nodes that
+need logic or a database lookup. Deferred nodes come back as segments with
+their type, their stored attributes as JSON, and their children already
+rendered. The render never runs your code. You splice the result in after
+it returns.
 
 ```rust,no_run
 use yrs::{Doc, Transact, ReadTxn};
@@ -121,15 +124,15 @@ let segments = render_segments(&txn, &fragment, &rules).expect("Lexical-shaped")
 let html = splice(segments);
 ```
 
-`Rules`, `Segment`, and `flatten` are re-exported here. Depend on this
-crate; [`yjs-html-core`](https://crates.io/crates/yjs-html-core) is
-internal.
+`Rules`, `Segment`, and `flatten` are re-exported here.
+[`yjs-html-core`](https://crates.io/crates/yjs-html-core) is an internal
+implementation crate.
 
 ## Schema discovery
 
-Editors name their types and attributes however they like, and Lexical
-prefixes its own props with `__`. `collect_node_types` reports what a
-document actually holds:
+Editors store types and attributes under their own names. Lexical prefixes
+its own props with `__`. `collect_node_types` reports what a real document
+holds:
 
 ```rust,no_run
 use yrs::{Doc, Transact, ReadTxn};

--- a/ext/yrby/crates/lexical-html/src/lib.rs
+++ b/ext/yrby/crates/lexical-html/src/lib.rs
@@ -1,48 +1,61 @@
-//! Native HTML rendering of Lexical documents from the yrs collab structure —
-//! no Node process, no headless editor.
+//! HTML for Lexical documents, rendered from the Yjs structure the editor
+//! syncs. No Node process and no headless editor. A server that holds the
+//! document bytes produces the markup itself.
 //!
-//! This renders **core Lexical**: paragraphs, headings, quotes, code, lists
-//! and list items, tables, horizontal rules, links, and the whole text-format
-//! model. Everything Lexxy-specific — its own node types (attachments,
+//! This renders core Lexical: paragraphs, headings, quotes, code blocks,
+//! lists and list items, tables, horizontal rules, links, and the whole
+//! text-format model. Lexxy's additions live in the Ruby layer, as the
+//! `Y::Lexxy` renderer's rule set: its own node types (attachments,
 //! galleries, `early_escape_code`, `horizontal_divider`) and its decorations
-//! of core nodes (the table figure wrapper, header-cell styling, the
-//! nested-list-item class) — lives in the Ruby layer as the `Y::Lexxy`
-//! renderer's rule set, built on the same extension API apps use
-//! (`Y::Lexical` is the core base class). The Lexxy byte-parity guarantee is
-//! held there: the Ruby fixture tests and the live headless-Chrome e2e pin
-//! `Y::Lexxy#to_html` against a real editor's own serialized value. The
-//! native tests pin core output as regression goldens (stock Lexical has no
-//! canonical serializer to capture against).
+//! of core nodes (the figure around a table, header-cell styling, the
+//! nested-list-item class). That rule set uses the same extension API
+//! applications use. `Y::Lexical` is the core base class. The byte-parity
+//! guarantee is held there too: the Ruby fixture tests and the
+//! headless-Chrome end-to-end run pin `Y::Lexxy#to_html` against a real
+//! editor's serialized value. The tests in this crate pin core output as
+//! regression goldens. Stock Lexical has no canonical serializer to capture
+//! from.
 //!
-//! Prior art: `ueberdosis/tiptap-php` renders ProseMirror JSON to HTML in pure
-//! PHP — a schema-pinned renderer outside the JS runtime. This works from the
-//! collab (Yjs) structure rather than JSON.
+//! Prior art: `ueberdosis/tiptap-php` renders ProseMirror JSON to HTML in
+//! plain PHP, outside any JavaScript runtime. This crate does the same job
+//! from the collaborative (Yjs) structure.
 //!
-//! Storage model (verified against bytes captured from a live editor):
-//! - Blocks are `Y.XmlText` with a `__type` attribute (`paragraph`, `heading`
-//!   (+`__tag`), `quote`, `code` (+`__language`), `list`/`listitem`,
-//!   `table`/`tablerow`/`tablecell`, `link`/`autolink` (inline)).
-//! - Text runs are preceded by an embedded `Y.Map` carrying per-run metadata
-//!   (`__type: "text" | "code-highlight" | "tab"`, `__format` bitmask).
-//! - `linebreak` is a bare metadata map; `tab` is a map followed by a "\t" run.
-//! - Decorator nodes are `Y.XmlElement`s with their fields as plain
-//!   attributes (`horizontalrule` here; app/Lexxy decorators via rules).
+//! How Lexical stores a document, checked against bytes captured from a live
+//! editor:
 //!
-//! Text-format rendering follows the export pipeline Lexxy runs (Lexical's
-//! `$generateHtmlFromNodes` + sanitize), which is the only externally
-//! pinnable truth for formatting: inner tag `strong` (bold) / `em` (italic,
-//! when not bold); outer tag `code` / `mark` / `sub` / `sup`; an `<i>` wrap
-//! only when bold+italic combine (the `em` slot is taken); `<s>` / `<u>`
-//! wraps always; `<span>`s are unwrapped, so unformatted text is bare. A
-//! run's `__style` (highlight colors) survives on the createDOM tag,
-//! filtered to color/background-color; on a plain or s/u-only run it dies
-//! with the unwrapped span. Case-transform format bits are never rendered
-//! (their text-transform style is outside the sanitize whitelist).
+//! - Blocks are `Y.XmlText` with a `__type` attribute: `paragraph`,
+//!   `heading` (plus `__tag`), `quote`, `code` (plus `__language`), `list`
+//!   and `listitem`, `table`, `tablerow` and `tablecell`, and the inline
+//!   `link` and `autolink`.
+//! - Each text run is preceded by an embedded `Y.Map` with its metadata: a
+//!   `__type` of `text`, `code-highlight`, or `tab`, and a `__format`
+//!   bitmask.
+//! - A `linebreak` is a bare metadata map. A `tab` is a map followed by a
+//!   `"\t"` run.
+//! - Decorator nodes are `Y.XmlElement`s whose fields are plain attributes.
+//!   `horizontalrule` is handled here. Application and Lexxy decorators come
+//!   in through rules.
 //!
-//! Custom nodes: rules are registered by `__type` (see `yjs-html-core`) and
-//! consulted before the built-in arms, so they extend the schema or override
-//! a built-in. Declarative rules render here; callback rules emit
-//! `Segment::Deferred` for the caller to fill in after the render.
+//! Text formatting follows the export pipeline Lexxy runs: Lexical's
+//! `$generateHtmlFromNodes`, then sanitize. That output is the only
+//! formatting truth that can be pinned from outside. The inner tag is
+//! `strong` for bold, or `em` for italic without bold. The outer tag is
+//! `code`, `mark`, `sub`, or `sup`. An `<i>` wraps only when bold and italic
+//! combine, because the `em` slot is taken. `<s>` and `<u>` wrap whenever
+//! present. `<span>`s are unwrapped, so unformatted text is bare. A run's
+//! `__style` (highlight colors) survives on the createDOM tag, filtered to
+//! color and background-color. On a plain run, or one with only strike or
+//! underline, it goes away with the span. The case-transform format bits
+//! never render; their text-transform style is outside the sanitize
+//! whitelist.
+//!
+//! A node type with no rule still renders its text and child blocks, just
+//! unwrapped.
+//!
+//! Custom nodes register rules by `__type` (see `yjs-html-core`). A rule is
+//! consulted before the built-in arms, so it can extend the schema or
+//! replace a built-in. Declarative rules render here. Callback rules emit
+//! `Segment::Deferred` for the caller to fill in after the render returns.
 
 // README examples are living code: compile-checked on every cargo test.
 #[cfg(doctest)]

--- a/ext/yrby/crates/prosemirror-html/README.md
+++ b/ext/yrby/crates/prosemirror-html/README.md
@@ -1,11 +1,11 @@
 # prosemirror-yjs-html
 
-Renders a [ProseMirror](https://prosemirror.net) document to HTML straight
-from its Yjs form, using [yrs](https://crates.io/crates/yrs). No browser, no
-Node. It handles prosemirror-schema-basic and the prosemirror-tables family,
-and reads both naming styles editors use: Tiptap's `bulletList`/`bold` and
-prosemirror-schema-basic's `bullet_list`/`strong`. The tests check output
-byte-for-byte against documents captured from a real Tiptap editor.
+Renders a [ProseMirror](https://prosemirror.net) document to HTML from its
+Yjs representation, using [yrs](https://crates.io/crates/yrs). It covers
+prosemirror-schema-basic plus the prosemirror-tables family. It reads both
+naming styles editors use: Tiptap's `bulletList` and `bold`, and
+prosemirror-schema-basic's `bullet_list` and `strong`. The tests pin the
+output byte-for-byte to fixtures captured from a live Tiptap editor.
 
 ## Usage
 
@@ -15,8 +15,8 @@ prosemirror-yjs-html = "0.1"
 yrs = { version = "0.27", features = ["sync"] }
 ```
 
-Feed it a Yjs update. That is bytes from your store, a provider, or
-`Y.encodeStateAsUpdate` in the browser.
+The input is a Yjs update: bytes from a durable store, from a provider, or
+from `Y.encodeStateAsUpdate` in the browser.
 
 ```rust,no_run
 use yrs::updates::decoder::Decode;
@@ -37,13 +37,13 @@ let html = prosemirror_yjs_html::render(&txn, &fragment);
 ```
 
 One doc can hold several fragments. Pass the root name your editor binds.
-`render` returns `None` when the fragment isn't ProseMirror-shaped.
+`render` returns `None` when the fragment is not ProseMirror-shaped.
 
 ## Declarative rules
 
-For a node type the built-in schema doesn't know, write a rule: a tag,
-attribute templates, and a content slot. Declarative rules render in the
-transaction, no callback:
+A rule tells the renderer how to draw a node type the built-in schema does
+not know. A rule is a tag, attribute templates, and a content slot.
+Declarative rules render inside the document transaction with no callback.
 
 ```rust,no_run
 use yrs::{Doc, Transact, ReadTxn};
@@ -70,17 +70,18 @@ let html = flatten(segments).into_html().expect("no callback rules");
 // <aside class="callout callout--warning">…</aside>
 ```
 
-An attribute template mixes literal parts (`lit`) with stored attributes
-(`ref`), and drops out when it resolves empty. `content` is `inline` for
-formatted text, `blocks` for child blocks, or `none` for a leaf; `inline`
-is the default. `void: true` drops the closing tag. Point a rule at a
-built-in type to override it.
+An attribute template joins literal parts (`lit`) and stored-attribute
+references (`ref`). An attribute that resolves empty is omitted. `content`
+is `"inline"` for formatted text, `"blocks"` for child block nodes, or
+`"none"` for a leaf. `"inline"` is the default. `"void": true` skips the
+closing tag. A rule for a built-in type replaces how that type renders.
 
 ## Mark rules
 
-ProseMirror has two kinds of thing. Nodes are structure: paragraphs,
-lists, tables. Marks annotate runs of text: bold, links, comments. A mark
-rule registers under `"marks"` and wraps the runs that carry it:
+A ProseMirror document has nodes and marks. Nodes are structure:
+paragraphs, lists, tables. Marks annotate runs of text: bold, links,
+comments. A mark rule registers under `"marks"` and wraps the text runs
+that carry it.
 
 ```rust,no_run
 use yrs::{Doc, Transact, ReadTxn};
@@ -106,21 +107,21 @@ let html = flatten(segments).into_html().expect("no callback rules");
 // <span data-comment-id="c42">…</span>, wrapped outside the built-in marks.
 ```
 
-Built-in marks nest in a fixed order: subscript and superscript innermost,
-then highlight, underline, strike, italic, bold, a `textStyle` span, and
-link on the outside. `code` renders alone among the formatting marks, the
-way Tiptap's Code mark does. A custom mark wraps outside every built-in.
-Several custom marks on one run nest alphabetically by name, so the output
-doesn't depend on registration order. A rule named for a built-in mark
-(`bold`) replaces its markup and keeps the exclusivity.
+Built-in marks nest in a fixed order. Subscript and superscript are
+innermost, then highlight, underline, strike, italic, bold, a `textStyle`
+span, and link on the outside. `code` renders alone among the formatting
+marks, matching Tiptap's Code mark. A custom mark wraps outside every
+built-in. Several custom marks on one run nest alphabetically by name, so
+output never depends on registration order. A rule for a built-in mark name
+(`"bold"`) replaces its markup and keeps its exclusivity behavior.
 
 ## Callback rules
 
-Some nodes need real work, like a database lookup. Mark the rule
-`callback` and the renderer hands them back to you. Deferred nodes come
-back as segments with their type, attributes as JSON, and rendered
-children. The render never runs your code. You splice the result in after
-it returns:
+A rule marked `callback` hands the node to your code. Use it for nodes that
+need logic or a database lookup. Deferred nodes come back as segments with
+their type, their stored attributes as JSON, and their children already
+rendered. The render never runs your code. You splice the result in after
+it returns.
 
 ```rust,no_run
 use yrs::{Doc, Transact, ReadTxn};
@@ -158,15 +159,15 @@ let segments = render_segments(&txn, &fragment, &rules).expect("ProseMirror-shap
 let html = splice(segments);
 ```
 
-`Rules`, `Segment`, and `flatten` are re-exported here. Depend on this
-crate; [`yjs-html-core`](https://crates.io/crates/yjs-html-core) is
-internal.
+`Rules`, `Segment`, and `flatten` are re-exported here.
+[`yjs-html-core`](https://crates.io/crates/yjs-html-core) is an internal
+implementation crate.
 
 ## Schema discovery
 
-Editors name their types and attributes however they like. Rhino Editor's
-strike mark, for one, is `rhino-strike`. `collect_node_types` reports what
-a document actually holds:
+Editors store types and attributes under their own names. Rhino Editor's
+strike mark, for example, is `rhino-strike`. `collect_node_types` reports
+what a real document holds:
 
 ```rust,no_run
 use yrs::{Doc, Transact, ReadTxn};

--- a/ext/yrby/crates/prosemirror-html/src/lib.rs
+++ b/ext/yrby/crates/prosemirror-html/src/lib.rs
@@ -1,40 +1,45 @@
-//! Native HTML rendering of ProseMirror/Tiptap documents from the yrs collab
-//! structure — no Node process, no headless editor.
+//! HTML for ProseMirror and Tiptap documents, rendered from the Yjs
+//! structure the editor syncs. No Node process and no headless editor.
 //!
-//! The y-prosemirror binding stores a document in a Y.XmlFragment: block nodes
-//! are Y.XmlElement (the tag is the node type, its attributes are the node
-//! attrs), and text is Y.XmlText whose per-run formatting attributes are the
-//! marks. Node and mark names come from the editor's schema, so this accepts
-//! both spellings in use: Tiptap's camelCase (`bulletList`, `bold`) and the
-//! prosemirror-schema-basic snake_case (`bullet_list`, `strong`).
+//! The y-prosemirror binding stores a document in a `Y.XmlFragment`. Block
+//! nodes are `Y.XmlElement`s: the tag is the node type and the attributes
+//! are the node attrs. Text is `Y.XmlText`, and each run's formatting
+//! attributes are its marks. Node and mark names come from the editor's
+//! schema, so both spellings are accepted: Tiptap's camelCase (`bulletList`,
+//! `bold`) and prosemirror-schema-basic's snake_case (`bullet_list`,
+//! `strong`).
 //!
-//! This renders **core ProseMirror**: the prosemirror-schema-basic node set
-//! plus the prosemirror-tables family — paragraphs, headings, blockquotes,
-//! code blocks, bullet/ordered lists, images, hard breaks, horizontal rules,
-//! and tables (semantic `<table><tbody>…`, without the `<colgroup>`/
-//! `min-width` styling editor views inject). Tiptap's extension nodes — task
-//! lists, mentions, the details family — live in the Ruby layer as the
-//! `Y::Tiptap` renderer's rule set, built on the same extension API apps use
-//! (`Y::ProseMirror` is the core base class). Output follows
-//! `ueberdosis/tiptap-php`, and with `Y::Tiptap`'s rules it matches Tiptap's
-//! own `getHTML()` byte for byte on the captured fixtures — that guarantee
-//! is held at the Ruby layer; the native tests pin core output as goldens
-//! where a fixture contains Tiptap-only nodes.
+//! This renders core ProseMirror: the prosemirror-schema-basic node set plus
+//! the prosemirror-tables family. That is paragraphs, headings, blockquotes,
+//! code blocks, bullet and ordered lists, images, hard breaks, horizontal
+//! rules, and tables as semantic `<table><tbody>…`, without the
+//! `<colgroup>` and `min-width` styling an editor view injects. Tiptap's
+//! extension nodes (task lists, mentions, the details family) live in the
+//! Ruby layer as the `Y::Tiptap` renderer's rule set, built on the same
+//! extension API applications use. `Y::ProseMirror` is the core base class.
+//! The output follows `ueberdosis/tiptap-php`. With `Y::Tiptap`'s rules it
+//! matches Tiptap's own `getHTML()` byte for byte on the captured fixtures.
+//! That guarantee is held at the Ruby layer. Where a fixture contains
+//! Tiptap-only nodes, the tests here pin core output as goldens.
 //!
-//! Marks stay native on purpose: mark serialization is text-run machinery
-//! (nesting order, textStyle's CSS, code's exclusivity), which the rule
-//! system can't express. The built-in set covers schema-basic's marks and
-//! Tiptap's — nesting outermost-first: link, a textStyle span, bold, italic,
-//! strike, underline, highlight, then subscript/superscript. `code` excludes
-//! the other formatting marks, so a code run is `<code>` alone — though a
+//! Marks stay native on purpose. Mark serialization is text-run machinery
+//! (nesting order, textStyle's CSS, code's exclusivity) that the rule system
+//! cannot express. The built-in set covers schema-basic's marks and
+//! Tiptap's, nested outermost-first: link, a textStyle span, bold, italic,
+//! strike, underline, highlight, then subscript and superscript. `code`
+//! excludes the other formatting marks, so a code run is `<code>` alone. A
 //! link still wraps it (see `render_run`).
 //!
-//! Custom nodes and marks: apps register rules by node type and mark name
-//! (see `render_rules`). A node rule is consulted before the built-in arms, so
-//! it can extend the schema or override a built-in; a mark rule claims its
-//! mark from the built-in wraps and wraps outside everything, link included.
-//! Declarative rules render here; callback rules emit `Segment::Deferred` for
-//! the caller to fill in after the render.
+//! A node type with no rule still renders its text and child blocks, just
+//! unwrapped.
+//!
+//! Applications register custom nodes and marks as rules keyed by node type
+//! and mark name (see `render_rules`). A node rule is consulted before the
+//! built-in arms, so it can extend the schema or replace a built-in. A mark
+//! rule claims its mark from the built-in wraps and wraps outside
+//! everything, link included. Declarative rules render here. Callback rules
+//! emit `Segment::Deferred` for the caller to fill in after the render
+//! returns.
 
 // README examples are living code: compile-checked on every cargo test.
 #[cfg(doctest)]


### PR DESCRIPTION
The crates.io READMEs and the docs.rs front pages of the three renderer crates say the same things in short, declarative sentences. Prose only: every code block is byte-identical to main, so the README doctests compile unchanged. Verified locally: crate tests, README doctests, and cargo doc with -D warnings all pass.