### PR TITLE
Add Doc#read_array for array-rooted documents

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
   NewCops: enable
   SuggestExtensions: false
   Exclude:
-    # ERB, not Ruby — the migration template interpolates the AR version.
+    # ERB, not Ruby: the migration template interpolates the AR version.
     - "lib/generators/yrby/install/templates/**/*"
     - "lib/generators/yrby/tables/templates/**/*"
     - "ext/**/*"          # Rust extension

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Node process:
 doc.read_text("prosemirror")  # => plain text of a Y.Text root, or nil
 doc.read_xml("root")          # => text of an XML root, one block per line
 doc.read_map("state")         # => a Y.Map root as a JSON string; JSON.parse it
+doc.read_array("cards")       # => a Y.Array root as a JSON string; JSON.parse it
 ```
 
 ### Pending structs and gap-free state

--- a/Rakefile
+++ b/Rakefile
@@ -38,19 +38,19 @@ namespace :release do
       two gems together when the shared core API changes. JP runs the push steps
       (RubyGems MFA, npm auth, and the default-branch guard).
 
-      1) yrby #{core}  — core gem, native extension; precompiled platform gems via CI
+      1) yrby #{core}: core gem, native extension; precompiled platform gems via CI
          a. bump lib/y/version.rb + CHANGELOG.md, then commit
          b. git tag v#{core} && git push origin main "v#{core}"
          c. the "Precompiled gems" workflow builds 8 platform gems + the source gem
          d. gh run download <run-id> --dir tmp/ ; cp tmp/**/*.gem pkg/
          e. for g in pkg/yrby-#{core}*.gem; do gem push "$g" || break; done   # 9 gems (gem push takes ONE at a time)
 
-      2) yrby-rails #{cable}  — gem, pure Ruby; one gem, no precompilation
+      2) yrby-rails #{cable}: gem, pure Ruby; one gem, no precompilation
          a. bump lib/yrby/rails/version.rb + CHANGELOG-rails.md, commit
          b. rake rails_gem:build
          c. gem push pkg/yrby-rails-#{cable}.gem
 
-      3) yrby-client #{npm}  — npm package (client SDK: provider + sync engine + reliable delivery)
+      3) yrby-client #{npm}: npm package (client SDK: provider + sync engine + reliable delivery)
          a. bump packages/client/package.json version, commit
          b. cd packages/client && npm publish
 

--- a/ext/yrby/src/lib.rs
+++ b/ext/yrby/src/lib.rs
@@ -200,6 +200,20 @@ impl RbDoc {
         })
     }
 
+    /// A `Y.Array` root serialized to a JSON array string (values recursive, in
+    /// array order). The counterpart to read_map for documents whose root is an
+    /// array — a board's cards, a sheet's rows. Callers parse the JSON (e.g.
+    /// `JSON.parse(doc.read_array("cards"))`). The serialization lives in
+    /// `read::array_json` (pure, Rust-tested).
+    fn read_array(&self, name: String) -> Option<String> {
+        let doc = &self.0;
+        nogvl(move || {
+            let txn = doc.transact();
+            let array = txn.get_array(name.as_str())?;
+            Some(read::array_json(&txn, &array))
+        })
+    }
+
     /// True if the doc holds un-integrable pending structs or a pending delete
     /// set — content that couldn't integrate because a causally-prior update is
     /// missing. Such content is a recovery buffer, not document state; it heals if
@@ -627,6 +641,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     doc_class.define_method("read_text", method!(RbDoc::read_text, 1))?;
     doc_class.define_method("read_xml", method!(RbDoc::read_xml, 1))?;
     doc_class.define_method("read_map", method!(RbDoc::read_map, 1))?;
+    doc_class.define_method("read_array", method!(RbDoc::read_array, 1))?;
     doc_class.define_method("pending?", method!(RbDoc::pending, 0))?;
     doc_class.define_method(
         "compacted_state_update",

--- a/ext/yrby/src/lib.rs
+++ b/ext/yrby/src/lib.rs
@@ -168,7 +168,7 @@ impl RbDoc {
         let doc = &self.0;
         nogvl(move || {
             // Exactly ONE transaction per call. Opening a second while the
-            // first is still held deadlocks against a waiting writer — and
+            // first is still held deadlocks against a waiting writer, and
             // inside nogvl that hang can't be interrupted.
             let txn = doc.transact();
             txn.get_text(name.as_str()).map(|t| t.get_string(&txn))
@@ -202,7 +202,7 @@ impl RbDoc {
 
     /// A `Y.Array` root serialized to a JSON array string (values recursive, in
     /// array order). The counterpart to read_map for documents whose root is an
-    /// array — a board's cards, a sheet's rows. Callers parse the JSON (e.g.
+    /// array: a board's cards, a sheet's rows. Callers parse the JSON (e.g.
     /// `JSON.parse(doc.read_array("cards"))`). The serialization lives in
     /// `read::array_json` (pure, Rust-tested).
     fn read_array(&self, name: String) -> Option<String> {
@@ -215,7 +215,7 @@ impl RbDoc {
     }
 
     /// True if the doc holds un-integrable pending structs or a pending delete
-    /// set — content that couldn't integrate because a causally-prior update is
+    /// set: content that couldn't integrate because a causally-prior update is
     /// missing. Such content is a recovery buffer, not document state; it heals if
     /// the missing dependency later arrives. A pure read.
     fn pending(&self) -> bool {
@@ -225,7 +225,7 @@ impl RbDoc {
 
     /// Like `encode_state_as_update` (full state), but **gap-free**: it excludes
     /// any pending (un-integrable) structs and pending delete set. Use this when
-    /// persisting or serving state that other peers will apply — serving pending
+    /// persisting or serving state that other peers will apply. Serving pending
     /// content poisons their sync. Non-destructive: this doc keeps its pending, so
     /// a genuine gap still heals if its dependency arrives. (`encode_state_as_update`
     /// stays lossless for raw-update recovery.)
@@ -351,12 +351,12 @@ impl RbDoc {
 }
 
 // ============================================================================
-// Y::Lexical — schema-pinned rendering of Lexical/Lexxy documents
+// Y::Lexical: schema-pinned rendering of Lexical/Lexxy documents
 // ============================================================================
 
 /// A Lexical view over a `Y::Doc`. The schema knowledge lives here rather
 /// than on the schema-agnostic `Doc`: core Lexical natively, everything else
-/// through the render rules compiled at construction (see `render_rules` —
+/// through the render rules compiled at construction (see `render_rules`;
 /// the `Y::Lexxy` facade's rule set arrives that way). Holds a cheap clone of
 /// the doc (yrs `Doc` is an Arc handle), so it reads live state.
 ///
@@ -371,7 +371,7 @@ struct RbLexical {
 }
 
 impl RbLexical {
-    /// `Y::NativeLexical.new(doc, rules_json)` — the Y::Lexical facade
+    /// `Y::NativeLexical.new(doc, rules_json)`; the Y::Lexical facade
     /// compiles its `nodes:` config to the rules JSON.
     fn native_new(doc: &RbDoc, rules_json: String) -> Result<Self, Error> {
         Ok(RbLexical {
@@ -381,7 +381,7 @@ impl RbLexical {
     }
 
     /// Render the document's XML root (default `"root"`, Lexical's standard
-    /// collab root name) natively — no Node process or headless editor. The
+    /// collab root name) natively, with no Node process or headless editor. The
     /// native side renders core Lexical plus whatever the rules cover; with
     /// the rule set `Y::Lexxy` passes, output matches Lexxy's own serializer
     /// byte-for-byte on the reference fixtures (see `lexical_html.rs`). Returns nil when the root is missing or not
@@ -400,7 +400,7 @@ impl RbLexical {
         segments_result(segments)
     }
 
-    /// The document's node types as observed facts, JSON-encoded — the
+    /// The document's node types as observed facts, JSON-encoded, the
     /// native half of the facade's `node_types` discovery aid. Nil when the
     /// root is missing or not Lexical-shaped.
     fn node_types(&self, args: &[Value]) -> Result<Value, Error> {
@@ -429,13 +429,13 @@ impl RbLexical {
 }
 
 // ============================================================================
-// Y::ProseMirror — schema-pinned rendering of ProseMirror/Tiptap documents
+// Y::ProseMirror: schema-pinned rendering of ProseMirror/Tiptap documents
 // ============================================================================
 
 /// A ProseMirror view over a `Y::Doc`. The schema knowledge lives here rather
 /// than on the schema-agnostic `Doc`: core ProseMirror natively, everything
 /// else through the render rules compiled at construction (see
-/// `render_rules` — the `Y::Tiptap` facade's rule set arrives that way).
+/// `render_rules`; the `Y::Tiptap` facade's rule set arrives that way).
 /// Holds a cheap clone of the doc (yrs `Doc` is an Arc handle), so it reads
 /// live state.
 ///
@@ -450,7 +450,7 @@ struct RbProseMirror {
 }
 
 impl RbProseMirror {
-    /// `Y::NativeProseMirror.new(doc, rules_json)` — the Y::ProseMirror facade
+    /// `Y::NativeProseMirror.new(doc, rules_json)`; the Y::ProseMirror facade
     /// compiles its `nodes:`/`marks:` config to the rules JSON.
     fn native_new(doc: &RbDoc, rules_json: String) -> Result<Self, Error> {
         Ok(RbProseMirror {
@@ -480,7 +480,7 @@ impl RbProseMirror {
         segments_result(segments)
     }
 
-    /// The document's node types as observed facts, JSON-encoded — the
+    /// The document's node types as observed facts, JSON-encoded, the
     /// native half of the facade's `node_types` discovery aid. Nil when the
     /// root is missing or not ProseMirror-shaped.
     fn node_types(&self, args: &[Value]) -> Result<Value, Error> {

--- a/ext/yrby/src/protocol.rs
+++ b/ext/yrby/src/protocol.rs
@@ -71,24 +71,24 @@ pub(crate) fn merged_doc_update(bytes: &[u8]) -> Result<Option<Vec<u8>>, String>
 ///
 /// This must be EXACT: the sync layer records on "ready" and resyncs on "not
 /// ready", and a parked update that slipped through would look like an
-/// already-applied retry downstream — acked and dropped, losing real content.
+/// already-applied retry downstream: acked and dropped, losing real content.
 ///
 /// Clocks alone can't decide it. An update can satisfy every per-client clock
 /// and still fail to integrate: its items may reference other clients' blocks
 /// (origins/parents), and merged updates hide internal gaps behind Skip blocks.
 /// So the clock lower bound serves only as a cheap definitive REJECT; "ready"
 /// is decided by trial-integrating on a throwaway probe seeded with the doc's
-/// integrated state — ready iff nothing parks.
+/// integrated state: ready iff nothing parks.
 pub(crate) fn update_is_ready(doc: &Doc, update_bytes: &[u8]) -> Result<bool, String> {
     let update = yrs::Update::decode_v1(update_bytes).map_err(|e| e.to_string())?;
-    // Partial order: "not covered" includes incomparable — not ready either way.
+    // Partial order: "not covered" includes incomparable: not ready either way.
     let lower_covered = doc.transact().state_vector() >= update.state_vector_lower();
     if !lower_covered {
         return Ok(false);
     }
     // Seed the probe with the doc's INTEGRATED state (gap-free), for two
     // reasons. A lossless seed would replant the doc's own pre-existing
-    // pending in the probe, making has_pending true for EVERY update — the
+    // pending in the probe, making has_pending true for EVERY update: the
     // verdict must be about this update, not the doc's baggage. And an update
     // whose dependency exists only in that pending buffer is genuinely not
     // ready: recording it would put a gap in the durable log; a resync heals
@@ -118,13 +118,13 @@ pub(crate) fn update_is_ready(doc: &Doc, update_bytes: &[u8]) -> Result<bool, St
 /// doc), then compare the probe before and after applying the update:
 ///
 /// - **Insert/format-only updates** grow the probe's state vector, so comparing
-///   the state vector is enough — and cheaper than a full re-encode.
+///   the state vector is enough, and cheaper than a full re-encode.
 /// - **Delete-bearing updates** don't move the state vector (a deletion tombstones
 ///   an existing struct rather than adding one), so we compare the full encoded
 ///   state, which carries the delete set. An already-applied pure-delete retry
 ///   re-encodes byte-identically → false; a genuinely new deletion changes the
 ///   delete set → true. This is exact but pays for two full encodes, so only
-///   delete-bearing frames — a minority — take that path.
+///   delete-bearing frames, a minority, take that path.
 ///
 /// Earlier this branch was conservative: any delete-bearing update returned true
 /// (record it), which double-recorded and re-broadcast pure-delete retries the
@@ -157,7 +157,7 @@ pub(crate) fn update_advances_doc(doc: &Doc, update_bytes: &[u8]) -> Result<bool
     }
 
     // Fast path: blocks beyond the doc's state vector are content the doc
-    // lacks — the update advances, no probe needed. The common case (a novel
+    // lacks: the update advances, no probe needed. The common case (a novel
     // edit) exits here; only retries and ambiguous diffs pay for the probe.
     if !has_deletes {
         let covered = doc.transact().state_vector() >= update.state_vector();
@@ -206,10 +206,10 @@ pub(crate) fn update_advances_doc(doc: &Doc, update_bytes: &[u8]) -> Result<bool
             return Ok(true);
         }
         // An unchanged state vector is ambiguous. Usually it means the doc
-        // already had everything in this update (a retry — return false, don't
+        // already had everything in this update (a retry: return false, don't
         // re-record). But it can ALSO mean the update failed to integrate and
         // was stashed as pending, which doesn't move the state vector either.
-        // That case is missing content, not a duplicate — returning false would
+        // That case is missing content, not a duplicate: returning false would
         // let a caller ack it and drop it. Distinguish the two by whether the
         // probe gained pending. (The sync flow screens gaps out with
         // update_is_ready before calling this; the check guards direct callers.)
@@ -240,7 +240,7 @@ pub(crate) fn has_pending(doc: &Doc) -> bool {
 /// Non-destructive: the prune happens only on the throwaway copy; `doc` keeps its
 /// pending, so a genuine gap still heals if its missing dependency later arrives.
 pub(crate) fn integrated_update(doc: &Doc, sv: &StateVector) -> Result<Vec<u8>, String> {
-    // Pending check and encode share ONE transaction — with two, a concurrent
+    // Pending check and encode share ONE transaction. With two, a concurrent
     // gappy apply_update could slip between them and the encode would serve
     // the very pending this function exists to exclude.
     let full = {
@@ -548,7 +548,7 @@ mod tests {
     // it and types between C's characters, so A's delta references C's blocks as
     // origins. Returns (c_update, a_delta). On a doc missing `c_update`, the
     // per-client clock lower bound of `a_delta` is satisfied (A starts at clock
-    // 0) but integration parks — the case a clock-only readiness check misses.
+    // 0) but integration parks: the case a clock-only readiness check misses.
     fn cross_client_origin_gap() -> (Vec<u8>, Vec<u8>) {
         let c = Doc::new();
         let ct = c.get_or_insert_text("t");
@@ -573,7 +573,7 @@ mod tests {
         let (c_update, a_delta) = cross_client_origin_gap();
 
         // A server that never saw C's content: the clock lower bound passes, but
-        // the update can't integrate — it must NOT be ready (previously it was,
+        // the update can't integrate: it must NOT be ready (previously it was,
         // and the downstream advances? probe then acked-and-dropped it).
         let server = Doc::new();
         assert!(
@@ -617,7 +617,7 @@ mod tests {
     fn a_doc_with_legacy_pending_still_accepts_healthy_updates() {
         // Why update_is_ready seeds its probe with the INTEGRATED state: with a
         // lossless seed, the doc's own pre-existing pending would park in the
-        // probe and every verdict would come back "not ready" — a server with
+        // probe and every verdict would come back "not ready": a server with
         // one legacy gap would reject every healthy keystroke forever.
         let (_first, dependent) = gap_pair();
         let doc = Doc::new();
@@ -645,7 +645,7 @@ mod tests {
     #[test]
     fn an_update_depending_only_on_pending_content_is_not_ready() {
         // The other half of the integrated-only seed: a dependency that exists
-        // solely in the doc's pending buffer doesn't count — recording such an
+        // solely in the doc's pending buffer doesn't count: recording such an
         // update would put a gap in the durable log. Not ready; resync heals
         // both as one complete delta.
         let src = Doc::new();
@@ -674,7 +674,7 @@ mod tests {
     #[test]
     fn update_advances_reports_true_when_the_update_would_park() {
         // Defense in depth for callers using advances? without the ready gate: a
-        // gappy update parks pending — that changes the doc, so it advances (it
+        // gappy update parks pending: that changes the doc, so it advances (it
         // must never be misread as an already-applied retry and dropped).
         let (_c_update, a_delta) = cross_client_origin_gap();
         let server = Doc::new();
@@ -896,7 +896,7 @@ mod tests {
         // for a fresh peer.
         //
         // Scope: this can't hit the original check-vs-encode race (its window
-        // is nanoseconds; never reproduced even at 20k iterations) — that fix
+        // is nanoseconds; never reproduced even at 20k iterations). That fix
         // is guaranteed by using a single transaction. What this catches is
         // coarser: encoding outside the lock, or a fast path skipping the
         // pending check.
@@ -914,7 +914,7 @@ mod tests {
             let first = first.clone();
             std::thread::spawn(move || {
                 while !stop.load(Ordering::Relaxed) {
-                    // Park a pending struct, then heal it, over and over — the
+                    // Park a pending struct, then heal it, over and over: the
                     // encode below keeps racing both transitions.
                     doc.transact_mut()
                         .apply_update(yrs::Update::decode_v1(&dependent).unwrap())

--- a/ext/yrby/src/read.rs
+++ b/ext/yrby/src/read.rs
@@ -1,4 +1,4 @@
-//! Pure content-reading helpers over yrs shared types — no magnus/Ruby, so they
+//! Pure content-reading helpers over yrs shared types, with no magnus/Ruby, so they
 //! can be unit-tested directly in Rust (like `protocol.rs`). The binding layer in
 //! `lib.rs` is a thin wrapper that opens a transaction and calls these.
 
@@ -18,7 +18,7 @@ use yrs::{
 ///   (`<paragraph>…`). `get_string` already recurses these (tags included; the
 ///   caller strips them), so we keep that path.
 /// - **Lexical** (Lexxy) stores every node as a `Y.XmlText`, and nests child
-///   blocks (list items, table cells, nested lists) as *embedded* `Y.XmlText`s —
+///   blocks (list items, table cells, nested lists) as *embedded* `Y.XmlText`s,
 ///   which `get_string` silently omits, dropping all that content. So for a
 ///   Lexical block we walk its content (`Text::diff`) instead: text runs build a
 ///   line, inline children (links) join it, and nested block children flush the
@@ -34,7 +34,7 @@ pub fn xml_blocks_text<T: ReadTxn>(txn: &T, fragment: &XmlFragmentRef) -> String
                 // them (tags kept, caller strips). A Lexical decorator is an
                 // XmlElement *with* a `__type`: attachments carry readable text
                 // (a mention's plain text, an upload's caption); the rest
-                // (horizontal rule) have none — skip rather than emit their
+                // (horizontal rule) have none: skip rather than emit their
                 // `<UNDEFINED …>` serialization.
                 if e.get_attribute(txn, "__type").is_none() {
                     out.push(e.get_string(txn));
@@ -161,7 +161,7 @@ fn walk_lexical_block<T: ReadTxn>(txn: &T, t: &XmlTextRef, out: &mut Vec<String>
 /// Read a `Y.Map` root as a JSON object string (object keys sorted at every
 /// depth for stable, diffable output).
 ///
-/// The complement to `read_text`/`read_xml` for structured state — e.g. a shared
+/// The complement to `read_text`/`read_xml` for structured state, e.g. a shared
 /// "view state" map. Values are converted recursively: primitives pass through;
 /// nested `Y.Map`/`Y.Array` recurse; `Y.Text`/XML values stringify. The caller
 /// parses the JSON (yrs's own `Out::to_json` is crate-private, so we walk the
@@ -187,7 +187,7 @@ pub fn array_json<T: ReadTxn>(txn: &T, array: &ArrayRef) -> String {
 /// `Any::to_json` iterates `Any::Map` (a `HashMap`) in arbitrary order, so a
 /// nested map would serialize unpredictably and differ run to run; sorting here
 /// makes the whole tree deterministic. Scalars defer to `Any::to_json`, which
-/// writes from the start of a buffer (it does not append) — hence each scalar
+/// writes from the start of a buffer (it does not append), hence each scalar
 /// gets its own fresh `String`.
 fn any_to_json(a: &Any) -> String {
     match a {
@@ -344,7 +344,7 @@ mod tests {
 
     #[test]
     fn map_json_sorts_nested_object_keys() {
-        // Nested maps sort their keys too, not just the root — yrs stores map
+        // Nested maps sort their keys too, not just the root: yrs stores map
         // entries in a HashMap, so without this the inner object serializes in
         // arbitrary, run-varying order.
         let doc = Doc::new();
@@ -476,8 +476,8 @@ mod tests {
     #[test]
     fn lexxy_full_schema_doc_extracts_attachment_text_too() {
         // The full-schema capture (see lexical_html.rs): attachments must now
-        // contribute readable text — a mention's plain text inline, an
-        // upload's caption as its own line — while the divider stays silent.
+        // contribute readable text (a mention's plain text inline, an
+        // upload's caption as its own line) while the divider stays silent.
         use yrs::updates::decoder::Decode;
         use yrs::{Transact, Update};
         let bytes = include_bytes!("../crates/lexical-html/src/fixtures/lexxy_full.bin");

--- a/ext/yrby/src/read.rs
+++ b/ext/yrby/src/read.rs
@@ -6,8 +6,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use yrs::types::text::YChange;
 use yrs::{
-    Any, Array, GetString, Map, MapRef, Out, ReadTxn, Text, Xml, XmlFragment, XmlFragmentRef,
-    XmlOut, XmlTextRef,
+    Any, Array, ArrayRef, GetString, Map, MapRef, Out, ReadTxn, Text, Xml, XmlFragment,
+    XmlFragmentRef, XmlOut, XmlTextRef,
 };
 
 /// Read an XML-shaped root as text, one top-level block per line.
@@ -158,7 +158,8 @@ fn walk_lexical_block<T: ReadTxn>(txn: &T, t: &XmlTextRef, out: &mut Vec<String>
     }
 }
 
-/// Read a `Y.Map` root as a JSON object string (keys sorted for stable output).
+/// Read a `Y.Map` root as a JSON object string (object keys sorted at every
+/// depth for stable, diffable output).
 ///
 /// The complement to `read_text`/`read_xml` for structured state — e.g. a shared
 /// "view state" map. Values are converted recursively: primitives pass through;
@@ -166,27 +167,61 @@ fn walk_lexical_block<T: ReadTxn>(txn: &T, t: &XmlTextRef, out: &mut Vec<String>
 /// parses the JSON (yrs's own `Out::to_json` is crate-private, so we walk the
 /// `Out` variants ourselves here).
 pub fn map_json<T: ReadTxn>(txn: &T, map: &MapRef) -> String {
-    let mut pairs: Vec<(String, Any)> = map
-        .iter(txn)
-        .map(|(k, v)| (k.to_string(), out_to_any(txn, &v)))
-        .collect();
-    pairs.sort_by(|a, b| a.0.cmp(&b.0)); // deterministic key order
-    let mut out = String::from("{");
-    for (i, (k, v)) in pairs.iter().enumerate() {
-        if i > 0 {
-            out.push(',');
-        }
-        // Any::to_json serializes from the start of the buffer (it doesn't
-        // append), so each piece goes into its own String, then concatenated.
-        out.push_str(&any_to_json(&Any::String(Arc::from(k.as_str())))); // JSON-escaped key
-        out.push(':');
-        out.push_str(&any_to_json(v));
+    let mut hm: HashMap<String, Any> = HashMap::new();
+    for (k, v) in map.iter(txn) {
+        hm.insert(k.to_string(), out_to_any(txn, &v));
     }
-    out.push('}');
-    out
+    any_to_json(&Any::Map(Arc::new(hm)))
 }
 
+/// A Y.Array's elements as a JSON array string, recursing through nested
+/// shared types exactly as `map_json` does (a Y.Map root and a Y.Array root are
+/// the two document shapes yrs can read from the top). Element order is the
+/// array's own order; nested object keys are sorted like map_json.
+pub fn array_json<T: ReadTxn>(txn: &T, array: &ArrayRef) -> String {
+    let items: Vec<Any> = array.iter(txn).map(|o| out_to_any(txn, &o)).collect();
+    any_to_json(&Any::Array(items.into()))
+}
+
+/// JSON-serialize an `Any` with object keys sorted at every depth. yrs's own
+/// `Any::to_json` iterates `Any::Map` (a `HashMap`) in arbitrary order, so a
+/// nested map would serialize unpredictably and differ run to run; sorting here
+/// makes the whole tree deterministic. Scalars defer to `Any::to_json`, which
+/// writes from the start of a buffer (it does not append) — hence each scalar
+/// gets its own fresh `String`.
 fn any_to_json(a: &Any) -> String {
+    match a {
+        Any::Array(items) => {
+            let mut out = String::from("[");
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push_str(&any_to_json(item));
+            }
+            out.push(']');
+            out
+        }
+        Any::Map(entries) => {
+            let mut pairs: Vec<(&String, &Any)> = entries.iter().collect();
+            pairs.sort_by(|a, b| a.0.cmp(b.0)); // deterministic key order
+            let mut out = String::from("{");
+            for (i, (key, value)) in pairs.into_iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push_str(&scalar_json(&Any::String(Arc::from(key.as_str())))); // JSON-escaped key
+                out.push(':');
+                out.push_str(&any_to_json(value));
+            }
+            out.push('}');
+            out
+        }
+        scalar => scalar_json(scalar),
+    }
+}
+
+fn scalar_json(a: &Any) -> String {
     let mut s = String::new();
     a.to_json(&mut s);
     s
@@ -308,11 +343,87 @@ mod tests {
     }
 
     #[test]
+    fn map_json_sorts_nested_object_keys() {
+        // Nested maps sort their keys too, not just the root — yrs stores map
+        // entries in a HashMap, so without this the inner object serializes in
+        // arbitrary, run-varying order.
+        let doc = Doc::new();
+        let map = doc.get_or_insert_map("state");
+        {
+            let mut txn = doc.transact_mut();
+            let inner = map.insert(&mut txn, "user", MapPrelim::default());
+            inner.insert(&mut txn, "name", "Ada");
+            inner.insert(&mut txn, "active", true);
+            inner.insert(&mut txn, "id", 7_i64);
+        }
+        let txn = doc.transact();
+        assert_eq!(
+            map_json(&txn, &map),
+            r#"{"user":{"active":true,"id":7,"name":"Ada"}}"#
+        );
+    }
+
+    #[test]
     fn map_json_empty_is_object() {
         let doc = Doc::new();
         let map = doc.get_or_insert_map("state");
         let txn = doc.transact();
         assert_eq!(map_json(&txn, &map), "{}");
+    }
+
+    #[test]
+    fn array_json_serializes_primitives_in_order() {
+        let doc = Doc::new();
+        let array = doc.get_or_insert_array("rows");
+        {
+            let mut txn = doc.transact_mut();
+            array.push_back(&mut txn, "a");
+            array.push_back(&mut txn, 2_i64);
+            array.push_back(&mut txn, true);
+        }
+        let txn = doc.transact();
+        assert_eq!(array_json(&txn, &array), r#"["a",2,true]"#);
+    }
+
+    #[test]
+    fn array_json_recurses_into_nested_maps() {
+        // The kanban/spreadsheet shape: an array of Y.Maps. Each element must
+        // come through as its own object, keys sorted like map_json.
+        let doc = Doc::new();
+        let array = doc.get_or_insert_array("cards");
+        {
+            let mut txn = doc.transact_mut();
+            let card = array.push_back(&mut txn, MapPrelim::default());
+            card.insert(&mut txn, "text", "Ship it");
+            card.insert(&mut txn, "column", "done");
+        }
+        let txn = doc.transact();
+        assert_eq!(
+            array_json(&txn, &array),
+            r#"[{"column":"done","text":"Ship it"}]"#
+        );
+    }
+
+    #[test]
+    fn array_json_recurses_into_nested_arrays() {
+        let doc = Doc::new();
+        let array = doc.get_or_insert_array("grid");
+        {
+            let mut txn = doc.transact_mut();
+            let row = array.push_back(&mut txn, yrs::ArrayPrelim::default());
+            row.push_back(&mut txn, 1_i64);
+            row.push_back(&mut txn, 2_i64);
+        }
+        let txn = doc.transact();
+        assert_eq!(array_json(&txn, &array), r#"[[1,2]]"#);
+    }
+
+    #[test]
+    fn array_json_empty_is_array() {
+        let doc = Doc::new();
+        let array = doc.get_or_insert_array("rows");
+        let txn = doc.transact();
+        assert_eq!(array_json(&txn, &array), "[]");
     }
 
     #[test]

--- a/lib/generators/yrby/install/install_generator.rb
+++ b/lib/generators/yrby/install/install_generator.rb
@@ -5,7 +5,7 @@ require "generators/yrby/tables/tables_generator"
 
 module Yrby
   module Generators
-    # `bin/rails generate yrby:install` — a DocumentChannel speaking the
+    # `bin/rails generate yrby:install`: a DocumentChannel speaking the
     # y-websocket protocol over the gem's document storage, plus the storage
     # migration (via yrby:tables). The models ship in the gem; only the
     # migration lands in the app.

--- a/lib/generators/yrby/tables/tables_generator.rb
+++ b/lib/generators/yrby/tables/tables_generator.rb
@@ -10,7 +10,7 @@ module Yrby
     # yrby:install, and by other gems building on the same storage.
     #
     # Template notes (kept here, not in the emitted migration): state is
-    # 1.gigabyte - 1 — the largest limit every adapter accepts. MySQL maps
+    # 1.gigabyte - 1: the largest limit every adapter accepts. MySQL maps
     # anything over 16 MB to longblob (a compacted snapshot is the whole
     # document; a 16 MB cap would break compaction); Postgres raises above
     # 1 GB - 1 and ignores the limit on bytea otherwise; SQLite ignores

--- a/lib/y/lexxy.rb
+++ b/lib/y/lexxy.rb
@@ -2,7 +2,7 @@
 
 module Y
   # The Lexxy renderer: Y::Lexical (core Lexical) plus the Lexxy-specific
-  # schema, applied beneath the app's rules — an app rule for one of these
+  # schema, applied beneath the app's rules: an app rule for one of these
   # types simply replaces it. This is the byte-parity class: the fixture
   # tests hold `Y::Lexxy.new(doc).to_html` identical to a live editor's own
   # serialized value.
@@ -36,7 +36,7 @@ module Y
       %(<th class="lexxy-content__table-cell--header" #{style}>#{node.content}</th>)
     end
 
-    # Attribute order follows Lexxy's export — checked items put aria-checked
+    # Attribute order follows Lexxy's export: checked items put aria-checked
     # before value; items holding a nested list append the
     # lexxy-nested-listitem class after value.
     def self.list_item(node)

--- a/lib/y/rendering.rb
+++ b/lib/y/rendering.rb
@@ -10,7 +10,7 @@ module Y
   # `marks:`. A rule is consulted before the built-in schema, so it can add a
   # custom node or override a built-in one.
   #
-  # The usual way in is the block form — one `rules.node` call per type,
+  # The usual way in is the block form, one `rules.node` call per type,
   # keyword options for markup-as-data, a Ruby block for logic (see Builder
   # below). `contains:` says what's inside the node: :inline (formatted
   # text, the default), :blocks (child block nodes), or :none (a leaf). The
@@ -26,7 +26,7 @@ module Y
   #                             attrs: { "class" => ["callout callout--", :kind] },
   #                             contains: :blocks
   #     end
-  #   `tag` is the element; `attrs` values are templates — a String literal,
+  #   `tag` is the element; `attrs` values are templates: a String literal,
   #   a Symbol referencing one of the node's stored attributes, or an Array
   #   mixing both (an attribute that resolves empty is omitted); `text` is a
   #   template for literal text content; `void: true` emits no closing tag;
@@ -45,20 +45,20 @@ module Y
   #   document is locked) and receives a RenderRules::Node with the node's
   #   type, stored attributes, children already rendered to HTML, and
   #   child_types (its element/block children by type). Its return value is
-  #   spliced in verbatim — it is trusted HTML, so escape any attribute
+  #   spliced in verbatim: it is trusted HTML, so escape any attribute
   #   values you interpolate.
   #
   # Mark rules (ProseMirror only) are declarative: `tag` plus `attrs`
   # templates whose Symbol refs resolve against the mark's own attributes. A
   # custom mark wraps outside every built-in mark; several custom marks nest
   # alphabetically. A rule for a built-in mark's stored name replaces its
-  # wrap (the markup changes, the semantics don't — an overridden code mark
+  # wrap (the markup changes, the semantics don't: an overridden code mark
   # still excludes the other formatting).
   module RenderRules
     # What a callback receives. `attrs` keys are as stored (Lexical's own
     # props keep their "__" prefix); `content` is the node's children,
     # already rendered to an HTML string; `child_types` lists the node's
-    # element/block children by type, in document order — the structural
+    # element/block children by type, in document order: the structural
     # facts attrs and content can't answer (a gallery's image count, whether
     # a list item holds a nested list).
     Node = Data.define(:type, :attrs, :content, :child_types)
@@ -137,7 +137,7 @@ module Y
     # from stored values. Text content escapes `&`, `<`, `>` (quotes stay
     # literal, matching the browser serializer); attribute values also
     # escape `"`. Prefer these over ERB::Util.html_escape when byte parity
-    # with editor output matters — html_escape also rewrites apostrophes.
+    # with editor output matters: html_escape also rewrites apostrophes.
     def escape_text(value)
       value.to_s.gsub("&", "&amp;").gsub("<", "&lt;").gsub(">", "&gt;")
     end
@@ -212,10 +212,10 @@ module Y
   # they compile the rules config, hold the callbacks, and splice deferred
   # segments after a render. The native handle does everything else.
   class Lexical
-    # `Y::Lexical.new(doc, nodes: { "type" => rule })` — see Y::RenderRules
+    # `Y::Lexical.new(doc, nodes: { "type" => rule })`; see Y::RenderRules
     # for the rule forms. This is core Lexical only: paragraphs, headings,
     # quotes, code, lists, tables, links, text formatting. Editor-specific
-    # nodes arrive as rules — Y::Lexxy subclasses this with the Lexxy schema;
+    # nodes arrive as rules. Y::Lexxy subclasses this with the Lexxy schema;
     # a different Lexical editor brings its own rule set the same way.
     def initialize(doc, nodes: {})
       builder = RenderRules::Builder.new(marks_allowed: false)
@@ -232,10 +232,10 @@ module Y
       RenderRules.splice(result, @render_callbacks)
     end
 
-    # What node types this document actually contains — the discovery aid
+    # What node types this document actually contains: the discovery aid
     # for writing rules. Facts per type: "count", "attrs" (names as stored),
     # "children" (child node types), "text" (whether it holds text runs),
-    # and "handled" ("builtin", "rule", or nil — nil marks the types you
+    # and "handled" ("builtin", "rule", or nil; nil marks the types you
     # still need a rule for). Children plus text is how you pick contains:.
     def node_types(root = nil)
       json = root.nil? ? @native.node_types : @native.node_types(root)
@@ -244,11 +244,11 @@ module Y
   end
 
   class ProseMirror
-    # `Y::ProseMirror.new(doc, nodes: {...}, marks: {...})` — see
+    # `Y::ProseMirror.new(doc, nodes: {...}, marks: {...})`; see
     # Y::RenderRules for the rule forms. This is core ProseMirror only:
     # prosemirror-schema-basic plus the prosemirror-tables family, and the
-    # full mark set (marks are native — see `rules.mark` for overrides).
-    # Editor-specific nodes arrive as rules — Y::Tiptap subclasses this with
+    # full mark set (marks are native; see `rules.mark` for overrides).
+    # Editor-specific nodes arrive as rules. Y::Tiptap subclasses this with
     # Tiptap's extension nodes; a different ProseMirror editor brings its
     # own rule set the same way.
     def initialize(doc, nodes: {}, marks: {})
@@ -267,10 +267,10 @@ module Y
       RenderRules.splice(result, @render_callbacks)
     end
 
-    # What node types this document actually contains — the discovery aid
+    # What node types this document actually contains: the discovery aid
     # for writing rules. Facts per type: "count", "attrs" (names as stored),
     # "children" (child node types), "text" (whether it holds text runs),
-    # and "handled" ("builtin", "rule", or nil — nil marks the types you
+    # and "handled" ("builtin", "rule", or nil; nil marks the types you
     # still need a rule for). Children plus text is how you pick contains:.
     def node_types(root = nil)
       json = root.nil? ? @native.node_types : @native.node_types(root)

--- a/lib/y/tiptap.rb
+++ b/lib/y/tiptap.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 module Y
-  # The Tiptap renderer: Y::ProseMirror (core ProseMirror — schema-basic plus
-  # tables) plus Tiptap's extension nodes, applied beneath the app's rules —
+  # The Tiptap renderer: Y::ProseMirror (core ProseMirror, schema-basic plus
+  # tables) plus Tiptap's extension nodes, applied beneath the app's rules,
   # an app rule for one of these types simply replaces it. This is the
   # byte-parity class: the fixture tests hold `Y::Tiptap.new(doc).to_html`
   # identical to a live editor's own `getHTML()`.
   #
   # Tiptap's marks (underline, highlight, sub/superscript, textStyle) render
-  # natively in the base class — mark serialization is text-run machinery
+  # natively in the base class: mark serialization is text-run machinery
   # the rule system can't express.
   class Tiptap < ProseMirror
     # Tiptap's TaskItem markup: the data-checked flag (false when unset), a

--- a/test/decoder_test.rb
+++ b/test/decoder_test.rb
@@ -21,6 +21,8 @@ class DecoderTest < Minitest::Test
 
   # A Y.Map "state" = { title: "Dashboard", count: 3, active: true, price: 9.99 }.
   MAP = "AQSP+KW4BQAoAQVzdGF0ZQV0aXRsZQF3CURhc2hib2FyZCgBBXN0YXRlBWNvdW50AX0DKAEFc3RhdGUGYWN0aXZlAXgoAQVzdGF0ZQVwcmljZQF7QCP64UeuFHsA"
+  # A Y.Array "cards" of two Y.Maps -- the kanban/spreadsheet shape.
+  ARRAY = "AQiMovTdCAAHAQVjYXJkcwEoAIyi9N0IAAJpZAF3ATEoAIyi9N0IAAR0ZXh0AXcORGVzaWduIHRoZSBBUEkoAIyi9N0IAAZjb2x1bW4BdwR0b2Rvh4yi9N0IAAEoAIyi9N0IBAJpZAF3ATIoAIyi9N0IBAR0ZXh0AXcHU2hpcCBpdCgAjKL03QgEBmNvbHVtbgF3BGRvbmUA"
   # rubocop:enable Layout/LineLength
 
   def decode(b64)
@@ -96,5 +98,27 @@ class DecoderTest < Minitest::Test
     doc.apply_update(decode(MAP))
 
     assert_nil doc.read_map("nope")
+  end
+
+  # --- read_array (array-rooted state) --------------------------------------
+
+  def test_read_array_returns_elements_as_json
+    doc = Y::Doc.new
+    doc.apply_update(decode(ARRAY))
+
+    assert_equal(
+      [
+        { "id" => "1", "text" => "Design the API", "column" => "todo" },
+        { "id" => "2", "text" => "Ship it", "column" => "done" }
+      ],
+      JSON.parse(doc.read_array("cards"))
+    )
+  end
+
+  def test_read_array_missing_root_is_nil
+    doc = Y::Doc.new
+    doc.apply_update(decode(ARRAY))
+
+    assert_nil doc.read_array("nope")
   end
 end


### PR DESCRIPTION
`Doc#read_array` reads a `Y.Array` root back as a JSON string, alongside the existing `read_text`, `read_xml`, and `read_map`. Documents whose top level is an array (a kanban board, a list of records, a spreadsheet's rows) previously had no server-side reader.

JSON generation sorts object keys at every depth, so the output is deterministic and can be compared in tests and fixtures.

Covered by unit tests over fixtures captured from real documents, and by the README example block, which the readme test executes.